### PR TITLE
(SIMP-998) Remove custom type deprecation from selinux

### DIFF
--- a/build/pupmod-selinux.spec
+++ b/build/pupmod-selinux.spec
@@ -1,7 +1,7 @@
 Summary: SELinux Puppet Module
 Name: pupmod-selinux
 Version: 1.0.0
-Release: 5
+Release: 6
 License: Apache License, Version 2.0
 Group: Applications/System
 Source: %{name}-%{version}-%{release}.tar.gz
@@ -49,6 +49,9 @@ mkdir -p %{buildroot}/%{prefix}/selinux
 # Post uninitall stuff
 
 %changelog
+* Tue Apr 12 2016 Kendall Moore <kendall.moore@onyxpoint.com> - 1.0.0-6
+- Removed custom type deprecation warning
+
 * Thu Feb 25 2016 Ralph Wright <ralph.wright@onyxpoint.com> - 1.0.0-5
 - Added compliance function support
 

--- a/lib/puppet/type/selinux_state.rb
+++ b/lib/puppet/type/selinux_state.rb
@@ -1,41 +1,39 @@
-module Puppet
-  newtype(:selinux_state) do
-    @doc = "Toggle the enforcement of selinux"
+Puppet::Type.newtype(:selinux_state) do
+  @doc = "Toggle the enforcement of selinux"
 
 
-    newparam(:name, :namevar => true) do
-      desc "An arbitrary, but unique, name for the resource."
-    end
-
-    newproperty(:ensure) do
-      defaultto(:enforcing)
-      newvalues(:false,:true,:disabled,:permissive,:enforcing)
-
-      munge do |value|
-        case value
-          when true,'true'
-            value = :enforcing
-          when false,'false'
-            value = :disabled
-        end
-
-        value
-      end
-    end
-
-    # Autorequire ALL Selbooleans
-    autorequire(:selboolean) do
-      req = []
-      resource = catalog.resources.find_all { |r|
-        r.is_a?(Puppet::Type.type(:selboolean))
-      }
-      if not resource.empty? then
-        req << resource
-      end
-      req.flatten!
-      req.each { |r| debug "Autorequiring #{r}" }
-      req
-    end
-
+  newparam(:name, :namevar => true) do
+    desc "An arbitrary, but unique, name for the resource."
   end
+
+  newproperty(:ensure) do
+    defaultto(:enforcing)
+    newvalues(:false,:true,:disabled,:permissive,:enforcing)
+
+    munge do |value|
+      case value
+        when true,'true'
+          value = :enforcing
+        when false,'false'
+          value = :disabled
+      end
+
+      value
+    end
+  end
+
+  # Autorequire ALL Selbooleans
+  autorequire(:selboolean) do
+    req = []
+    resource = catalog.resources.find_all { |r|
+      r.is_a?(Puppet::Type.type(:selboolean))
+    }
+    if not resource.empty? then
+      req << resource
+    end
+    req.flatten!
+    req.each { |r| debug "Autorequiring #{r}" }
+    req
+  end
+
 end


### PR DESCRIPTION
Updated the selinux_state custom type to remove a deprecation warning
that occurs in Puppet 4

SIMP-995 #comment Fixes the pupmod-simp-selinux part of the story
SIMP-998 #close