### PR TITLE
(SIMP-1135) Install policycoreutils-python by default.

### DIFF
--- a/build/pupmod-selinux.spec
+++ b/build/pupmod-selinux.spec
@@ -1,6 +1,6 @@
 Summary: SELinux Puppet Module
 Name: pupmod-selinux
-Version: 1.0.1
+Version: 1.0.2
 Release: 0
 License: Apache License, Version 2.0
 Group: Applications/System
@@ -49,6 +49,9 @@ mkdir -p %{buildroot}/%{prefix}/selinux
 # Post uninitall stuff
 
 %changelog
+* Tue Jun 21 2016 Nick Markowski <nmarkowski@keywcorp.com> - 1.0.2-0
+- policycoreutils-python now installed by default.
+
 * Tue Apr 12 2016 Kendall Moore <kendall.moore@onyxpoint.com> - 1.0.1-0
 - Removed custom type deprecation warning
 

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -1,22 +1,37 @@
 #
 # Class: selinux
 #
+# Parameters
+#
+# $ensure
+# Type: String
+# Default: 'enforcing'
+#   The state that SELinux should be in.
+#   Valid values are: true, false, 'enforcing', 'permissive', 'disabled'.
+#   Since you are calling this class, we assume that you want to enforce.
+#
+# $mode
+# Type: String
+# Default: 'targeted'
+#   The SELinux type you want to enforce.
+#   Valid values are: 'targeted', 'mls'
+#   Note, it is quite possible that 'mls' will render your system inoperable.
+#
+# $manage_utils_package
+# Type: Boolean
+# Default: true
+#   If true, ensure policycoreutils-python is installed.
+#
 # Additional functionality for SELinux support.
 #
 class selinux (
-# _Variables
-# $ensure
-#     The state that SELinux should be in.
-#     Valid values are: true, false, 'enforcing', 'permissive', 'disabled'.
-#     Since you are calling this class, we assume that you want to enforce.
-  $ensure = 'enforcing',
-# $mode
-#     The SELinux type you want to enforce.
-#     Valid values are: 'targeted', 'mls'
-#     Note, it is quite possible that 'mls' will render your system inoperable.
-  $mode = 'targeted'
+  $ensure               = 'enforcing',
+  $manage_utils_package = true,
+  $mode                 = 'targeted'
 ) {
   validate_array_member($mode,['targeted','mls'])
+  validate_bool($manage_utils_package)
+  validate_array_member($ensure,[true,false,'enforcing','permissive','disabled'])
 
   compliance_map()
 
@@ -28,5 +43,11 @@ class selinux (
     group   => 'root',
     mode    => '0644',
     content => template('selinux/sysconfig.erb')
+  }
+
+  if $manage_utils_package {
+    package { 'policycoreutils-python':
+      ensure => 'latest'
+    }
   }
 }

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name":    "simp-selinux",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "author":  "SIMP",
   "summary": "manages the SELinux system state",
   "license": "Apache-2.0",

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -1,14 +1,21 @@
 require 'spec_helper'
 
 describe 'selinux' do
-  let(:facts) {{
-    :fqdn => 'test.host.net',
-    :hardwaremodel => 'x86_64',
-    :processorcount => 4,
-    :selinux => true,
-    :selinux_config_mode => 'permissive',
-    :selinux_enforced => true
-  }}
-
-  it { is_expected.to compile.with_all_deps }
+  context 'supported operating systems' do
+    on_supported_os.each do |os, facts|
+      context "on #{os}" do
+        let(:facts) do
+          facts
+        end
+        context 'with default parameters' do
+          it { is_expected.to compile.with_all_deps }
+          it { is_expected.to contain_package('policycoreutils-python').with(:ensure => 'latest') }
+        end
+        context 'with manage_utils_package => false' do
+          let(:params) {{:manage_utils_package => false}}
+          it { is_expected.to_not contain_package('policycoreutils-python') }
+        end
+      end
+    end
+  end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,6 +1,9 @@
-require 'pathname'
-require 'rspec-puppet'
 require 'puppetlabs_spec_helper/module_spec_helper'
+require 'rspec-puppet'
+require 'simp/rspec-puppet-facts'
+include Simp::RspecPuppetFacts
+
+require 'pathname'
 
 # RSpec Material
 fixture_path = File.expand_path(File.join(__FILE__, '..', 'fixtures'))
@@ -13,6 +16,12 @@ if Puppet.version < "4.0.0"
   end
 end
 
+
+if !ENV.key?( 'TRUSTED_NODE_DATA' )
+  warn '== WARNING: TRUSTED_NODE_DATA is unset, using TRUSTED_NODE_DATA=yes'
+  ENV['TRUSTED_NODE_DATA']='yes'
+end
+
 default_hiera_config =<<-EOM
 ---
 :backends:
@@ -20,11 +29,46 @@ default_hiera_config =<<-EOM
 :yaml:
   :datadir: "stub"
 :hierarchy:
-  # This is a variable that you can set in your test classes to ensure that the
-  # targeted YAML file gets loaded in the fixtures.
+  - "%{custom_hiera}"
   - "%{module_name}"
   - "default"
 EOM
+
+# This can be used from inside your spec tests to set the testable environment.
+# You can use this to stub out an ENC.
+#
+# Example:
+#
+# context 'in the :foo environment' do
+#   let(:environment){:foo}
+#   ...
+# end
+#
+def set_environment(environment = :production)
+    RSpec.configure { |c| c.default_facts['environment'] = environment.to_s }
+end
+
+# This can be used from inside your spec tests to load custom hieradata within
+# any context.
+#
+# Example:
+#
+# describe 'some::class' do
+#   context 'with version 10' do
+#     let(:hieradata){ "#{class_name}_v10" }
+#     ...
+#   end
+# end
+#
+# Then, create a YAML file at spec/fixtures/hieradata/some__class_v10.yaml.
+#
+# Hiera will use this file as it's base of information stacked on top of
+# 'default.yaml' and <module_name>.yaml per the defaults above.
+#
+# Note: Any colons (:) are replaced with underscores (_) in the class name.
+def set_hieradata(hieradata)
+    RSpec.configure { |c| c.default_facts['custom_hiera'] = hieradata }
+end
 
 if not File.directory?(File.join(fixture_path,'hieradata')) then
   FileUtils.mkdir_p(File.join(fixture_path,'hieradata'))
@@ -34,15 +78,16 @@ if not File.directory?(File.join(fixture_path,'modules',module_name)) then
   FileUtils.mkdir_p(File.join(fixture_path,'modules',module_name))
 end
 
-Dir.chdir(File.join(fixture_path,'modules',module_name)) do
-  ['manifests','templates','lib'].each do |tgt|
-    if not File.symlink?(tgt) then
-      FileUtils.ln_sf("../../../../#{tgt}",tgt)
-    end
-  end
-end
-
 RSpec.configure do |c|
+  # If nothing else...
+  c.default_facts = {
+    :production => {
+      #:fqdn           => 'production.rspec.test.localdomain',
+      :path           => '/usr/local/sbin:/usr/local/bin:/sbin:/bin:/usr/sbin:/usr/bin',
+      :concat_basedir => '/tmp'
+    }
+  }
+
   c.mock_framework = :rspec
   c.mock_with :mocha
 
@@ -51,19 +96,52 @@ RSpec.configure do |c|
 
   c.hiera_config = File.join(fixture_path,'hieradata','hiera.yaml')
 
-  c.before(:all) do
-# Add fixture lib dirs to LOAD_PATH. Work-around for PUP-3336
-if Puppet.version < "4.0.0"
-  Dir["#{fixture_path}/modules/*/lib"].entries.each do |lib_dir|
-    $LOAD_PATH << lib_dir
-  end
-end
+  # Useless backtrace noise
+  backtrace_exclusion_patterns = [
+    /spec_helper/,
+    /gems/
+  ]
 
+  if c.respond_to?(:backtrace_exclusion_patterns)
+    c.backtrace_exclusion_patterns = backtrace_exclusion_patterns
+  elsif c.respond_to?(:backtrace_clean_patterns)
+    c.backtrace_clean_patterns = backtrace_exclusion_patterns
+  end
+
+  c.before(:all) do
     data = YAML.load(default_hiera_config)
     data[:yaml][:datadir] = File.join(fixture_path, 'hieradata')
+
     File.open(c.hiera_config, 'w') do |f|
       f.write data.to_yaml
     end
+  end
+
+  c.before(:each) do
+    @spec_global_env_temp = Dir.mktmpdir('simpspec')
+
+    if defined?(environment)
+      set_environment(environment)
+      FileUtils.mkdir_p(File.join(@spec_global_env_temp,environment.to_s))
+    end
+
+    # ensure the user running these tests has an accessible environmentpath
+    Puppet[:environmentpath] = @spec_global_env_temp
+    Puppet[:user] = Etc.getpwuid(Process.uid).name
+    Puppet[:group] = Etc.getgrgid(Process.gid).name
+
+    # sanitize hieradata
+    if defined?(hieradata)
+      set_hieradata(hieradata.gsub(':','_'))
+    elsif defined?(class_name)
+      set_hieradata(class_name.gsub(':','_'))
+    end
+  end
+
+  c.after(:each) do
+    # clean up the mocked environmentpath
+    FileUtils.rm_rf(@spec_global_env_temp)
+    @spec_global_env_temp = nil
   end
 end
 


### PR DESCRIPTION
We want it.  Some modules need it.  Let's install it.

SIMP-1135 #close
