### PR TITLE
(SIMP-1398)  Kerberos and NFS

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -47,8 +47,10 @@ class selinux (
   }
 
   if $manage_utils_package {
-    package { 'policycoreutils-python':
-      ensure => 'latest'
+    if !defined(Package['policycoreutils-python']) {
+      package { 'policycoreutils-python':
+        ensure => 'latest'
+      }
     }
   }
 }


### PR DESCRIPTION
Several modules require the 'policycoreutils-python' package and
this checks if it is definied already before adding it.

SIMP-1398 #Fixes due to acceptance testing of NFS and krb5
