### PR TITLE
(SIMP-2947) Use simp_options::selinux

### DIFF
--- a/.puppet-lint.rc
+++ b/.puppet-lint.rc
@@ -2,5 +2,8 @@
 --relative
 --no-class_inherits_from_params_class-check
 --no-140chars-check
+--no-empty_string-check
 --no-trailing_comma-check
---no-empty_string_assignment-check
+# This is here because the code can't handle lookups in parameters and we have
+# a LOT of those
+--no-parameter_order-check

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,13 @@
-#  PE/SIMP versions
-#  app    pup  ruby
-# 2015.2  4.3  2.1.7
-# 2015.3  4.3  2.1.8
-# 2016.1  4.4  2.1.9
-# 2016.2  4.5  2.1.9
-# S6.0.0  4.7  2.1.9
+# The testing matrix considers ruby/puppet versions supported by SIMP and PE:
+# ------------------------------------------------------------------------------
+#  release    pup   ruby      eol
+# PE 2015.2   4.2   2.1.7  2017-03-17
+# PE 2015.3   4.3   2.1.8  2017-03-17
+# PE 2016.1   4.4   2.1.9  2017-03-17 (yes: all three EOL on the same day!)
+# PE 2016.2   4.5   2.1.9  2017-04-30
+# PE 2016.4   4.7   2.1.9  TBD (LTS)
+# PE 2016.5   4.8   2.1.9  TBD
+# SIMP6.0.0   4.8   2.1.9  TBD
 ---
 language: ruby
 sudo: false
@@ -24,17 +27,17 @@ env:
     - STRICT_VARIABLES=yes
     - TRUSTED_NODE_DATA=yes
   matrix:
+    - PUPPET_VERSION="~> 4.8.2"
     - PUPPET_VERSION="~> 4.7.0"
     - PUPPET_VERSION="~> 4.5.0"
-    - PUPPET_VERSION="~> 3.8.0"
     - PUPPET_VERSION="~> 4.4.0"
     - PUPPET_VERSION="~> 4.3.0"
-    - PUPPET_VERSION="~> 3.8.0" FUTURE_PARSER=yes
+    - PUPPET_VERSION="~> 4.2.0"
 matrix:
   fast_finish: true
   allow_failures:
+    - env: PUPPET_VERSION="~> 4.7.0"
     - env: PUPPET_VERSION="~> 4.5.0"
-    - env: PUPPET_VERSION="~> 3.8.0"
     - env: PUPPET_VERSION="~> 4.4.0"
     - env: PUPPET_VERSION="~> 4.3.0"
-    - env: PUPPET_VERSION="~> 3.8.0" FUTURE_PARSER=yes
+    - env: PUPPET_VERSION="~> 4.2.0"

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,6 @@
+* Tue Mar 28 2016 Nick Miller <nick.miller@onyxpoint.com> 2.0.2-0
+- Respects simp_options::selinux
+
 * Tue Dec 20 2016 Nick Miller <nick.miller@onyxpoint.com> 2.0.1-0
 - Strongly typed module
 

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,5 +1,6 @@
-* Tue Mar 28 2016 Nick Miller <nick.miller@onyxpoint.com> 2.0.2-0
-- Respects simp_options::selinux
+* Tue Mar 28 2017 Nick Miller <nick.miller@onyxpoint.com> 2.0.2-0
+- Defaulted selinux::ensure to the selinux catalyst for better control
+  of selinux enforcement.
 
 * Tue Dec 20 2016 Nick Miller <nick.miller@onyxpoint.com> 2.0.1-0
 - Strongly typed module

--- a/Gemfile
+++ b/Gemfile
@@ -13,6 +13,7 @@ group :test do
   gem 'hiera-puppet-helper'
   gem 'puppetlabs_spec_helper'
   gem 'metadata-json-lint'
+  gem 'puppet-strings'
   gem 'puppet-lint-empty_string-check',   :require => false
   gem 'puppet-lint-trailing_comma-check', :require => false
   gem 'simp-rspec-puppet-facts', ENV.fetch('SIMP_RSPEC_PUPPET_FACTS_VERSION', '~> 1.3')
@@ -24,7 +25,6 @@ group :development do
   gem 'travis-lint'
   gem 'travish'
   gem 'puppet-blacksmith'
-  gem 'puppet-strings'
   gem 'guard-rake'
   gem 'pry'
   gem 'pry-doc'
@@ -35,8 +35,11 @@ group :development do
 end
 
 group :system_tests do
-  # This patch is required to fix Beaker's broken `aio` handling
-  gem 'beaker', :git => 'https://github.com/trevor-vaughan/beaker.git', :branch => 'BKR-931-2.51.0'
+  # This patch is required to fix Beaker's broken `aio` handling and provide support for SuSE
+  # If you want to use 'bundle update --local', comment out this line and uncomment the next line
+  # If you do this, please remember not to check in that change.
+  gem 'beaker', :git => 'https://github.com/trevor-vaughan/beaker.git', :branch => 'BKR-978-2.51.0'
+  # gem 'beaker'
   gem 'beaker-rspec'
   gem 'simp-beaker-helpers', ENV.fetch('SIMP_BEAKER_HELPERS_VERSION', '~> 1.5')
 end

--- a/Rakefile
+++ b/Rakefile
@@ -1,4 +1,4 @@
 require 'simp/rake/pupmod/helpers'
+require 'puppet-strings/tasks'
 
 Simp::Rake::Pupmod::Helpers.new(File.dirname(__FILE__))
-

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "simp-selinux",
-  "version": "2.0.1",
+  "version": "2.0.2",
   "author": "SIMP Team",
   "summary": "manages the SELinux system state",
   "license": "Apache-2.0",
@@ -41,11 +41,7 @@
   "requirements": [
     {
       "name": "puppet",
-      "version_requirement": "4.x"
-    },
-    {
-      "name": "pe",
-      "version_requirement": ">= 2016.2.0"
+      "version_requirement": ">= 4.6.0 < 5.0.0"
     }
   ]
 }

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -7,14 +7,67 @@ describe 'selinux' do
         let(:facts) do
           facts
         end
+
         context 'with default parameters' do
           it { is_expected.to compile.with_all_deps }
+          it { is_expected.to create_file('/etc/selinux/config').with_content(<<-EOF.gsub(/^\s+/,'')
+            # This file controls the state of SELinux on the system.
+            # SELINUX= can take one of these three values:
+            #	enforcing - SELinux security policy is enforced.
+            #	permissive - SELinux prints warnings instead of enforcing.
+            #	disabled - SELinux is fully disabled.
+            SELINUX=enforcing
+            # SELINUXTYPE= type of policy in use. Possible values are:
+            #	targeted - Only targeted network daemons are protected.
+            #	strict - Full SELinux protection.
+            SELINUXTYPE=targeted
+            EOF
+            ) }
+          it { is_expected.to contain_package('checkpolicy').with(:ensure => 'latest') }
           it { is_expected.to contain_package('policycoreutils-python').with(:ensure => 'latest') }
         end
+
+        context 'with ensure set to a non-boolean' do
+          let(:params) {{ :ensure => 'permissive' }}
+          it { is_expected.to compile.with_all_deps }
+          it { is_expected.to create_file('/etc/selinux/config').with_content(<<-EOF.gsub(/^\s+/,'')
+            # This file controls the state of SELinux on the system.
+            # SELINUX= can take one of these three values:
+            #	enforcing - SELinux security policy is enforced.
+            #	permissive - SELinux prints warnings instead of enforcing.
+            #	disabled - SELinux is fully disabled.
+            SELINUX=permissive
+            # SELINUXTYPE= type of policy in use. Possible values are:
+            #	targeted - Only targeted network daemons are protected.
+            #	strict - Full SELinux protection.
+            SELINUXTYPE=targeted
+            EOF
+            ) }
+        end
+
+        context 'with mode set' do
+          let(:params) {{ :mode => 'mls' }}
+          it { is_expected.to compile.with_all_deps }
+          it { is_expected.to create_file('/etc/selinux/config').with_content(<<-EOF.gsub(/^\s+/,'')
+            # This file controls the state of SELinux on the system.
+            # SELINUX= can take one of these three values:
+            #	enforcing - SELinux security policy is enforced.
+            #	permissive - SELinux prints warnings instead of enforcing.
+            #	disabled - SELinux is fully disabled.
+            SELINUX=enforcing
+            # SELINUXTYPE= type of policy in use. Possible values are:
+            #	targeted - Only targeted network daemons are protected.
+            #	strict - Full SELinux protection.
+            SELINUXTYPE=mls
+            EOF
+            ) }
+        end
+
         context 'with manage_utils_package => false' do
           let(:params) {{:manage_utils_package => false}}
           it { is_expected.to_not contain_package('policycoreutils-python') }
         end
+
       end
     end
   end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -84,7 +84,7 @@ RSpec.configure do |c|
     :production => {
       #:fqdn           => 'production.rspec.test.localdomain',
       :path           => '/usr/local/sbin:/usr/local/bin:/sbin:/bin:/usr/sbin:/usr/bin',
-      :concat_basedir => '/tmp'
+      :concat_basedir => '/tmp',
     }
   }
 

--- a/spec/spec_helper_acceptance.rb
+++ b/spec/spec_helper_acceptance.rb
@@ -28,11 +28,7 @@ RSpec.configure do |c|
     begin
       # Install modules and dependencies from spec/fixtures/modules
       copy_fixture_modules_to( hosts )
-      begin
-        server = only_host_with_role(hosts, 'server')
-      rescue ArgumentError =>e
-        server = only_host_with_role(hosts, 'default')
-      end
+      server = only_host_with_role(hosts, 'server')
 
       # Generate and install PKI certificates on each SUT
       Dir.mktmpdir do |cert_dir|

--- a/templates/sysconfig.erb
+++ b/templates/sysconfig.erb
@@ -3,7 +3,7 @@
 #	enforcing - SELinux security policy is enforced.
 #	permissive - SELinux prints warnings instead of enforcing.
 #	disabled - SELinux is fully disabled.
-SELINUX=<%= @ensure %>
+SELINUX=<%= @_state %>
 # SELINUXTYPE= type of policy in use. Possible values are:
 #	targeted - Only targeted network daemons are protected.
 #	strict - Full SELinux protection.

--- a/types/state.pp
+++ b/types/state.pp
@@ -1,0 +1,9 @@
+# Types of selinux enforcement
+type Selinux::State = Variant[
+  Boolean,
+  Enum[
+    'enforcing',
+    'permissive',
+    'disabled'
+  ]
+]


### PR DESCRIPTION
Previously, this module didn't respect simp_options::selinux. Now it
will look up the globally set option, and fallback to enforcing if now
found.

SIMP-2947 #close