### PR TITLE
(SIMP-2684) Manage mcstrans in selinux module

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,7 @@
+* Wed Apr 26 2017 Nick Miller <nick.miller@onyxpoint.com> - 2.1.0-0
+- Moved management of mcstrans and restorecond to the selinux module
+- Change default packages ensure to use the catalyst
+
 * Mon Apr 17 2017 Nick Markowski <nmarkowski@keywcorp.com> - 2.0.3-0
 - Fixed a bug wherein setenforce would run if selinux was disabled
 - Changes in selinux state incur a reboot notification

--- a/data/common.yaml
+++ b/data/common.yaml
@@ -1,0 +1,5 @@
+---
+selinux::mcstrans::manage_package: true
+selinux::mcstrans::manage_service: true
+selinux::mcstrans::package_name: mcstrans
+selinux::mcstrans::manage_restorecond: false

--- a/data/os/CentOS-6.yaml
+++ b/data/os/CentOS-6.yaml
@@ -1,0 +1,3 @@
+---
+selinux::mcstrans::service_name: mcstrans
+selinux::mcstrans::manage_restorecond: true

--- a/data/os/CentOS-7.yaml
+++ b/data/os/CentOS-7.yaml
@@ -1,0 +1,2 @@
+---
+selinux::mcstrans::service_name: mcstransd

--- a/data/os/RedHat-6.yaml
+++ b/data/os/RedHat-6.yaml
@@ -1,0 +1,3 @@
+---
+selinux::mcstrans::service_name: mcstrans
+selinux::mcstrans::manage_restorecond: true

--- a/data/os/RedHat-7.yaml
+++ b/data/os/RedHat-7.yaml
@@ -1,0 +1,2 @@
+---
+selinux::mcstrans::service_name: mcstransd

--- a/hiera.yaml
+++ b/hiera.yaml
@@ -1,0 +1,10 @@
+---
+version: 4
+datadir: data
+hierarchy:
+  - name: "OS family - Major Release"
+    backend: yaml
+    path: "os/%{facts.os.family}-%{facts.os.release.major}"
+
+  - name: "common"
+    backend: yaml

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -15,8 +15,11 @@
 class selinux (
   Selinux::State         $ensure               = simplib::lookup('simp_options::selinux', { 'default_value' => true }),
   Boolean                $manage_utils_package = true,
+  String                 $package_ensure       = simplib::lookup('simp_options::package_ensure', { 'default_value' => 'installed' }),
   Enum['targeted','mls'] $mode                 = 'targeted'
 ) {
+
+  include 'selinux::mcstrans'
 
   selinux_state { 'set_selinux_state': ensure => $ensure }
 
@@ -38,9 +41,10 @@ class selinux (
 
   $utils_packages = [
     'checkpolicy',
-    'policycoreutils-python'
+    'policycoreutils-python',
   ]
   if $manage_utils_package {
-    ensure_resource('package', $utils_packages, { 'ensure' => 'latest' })
+    ensure_resource('package', $utils_packages, { 'ensure' => $package_ensure })
   }
+
 }

--- a/manifests/mcstrans.pp
+++ b/manifests/mcstrans.pp
@@ -23,6 +23,7 @@ class selinux::mcstrans (
 
   if $manage_service {
     service { $service_name:
+      ensure     => 'running',
       enable     => true,
       hasrestart => true,
       hasstatus  => false,

--- a/manifests/mcstrans.pp
+++ b/manifests/mcstrans.pp
@@ -1,0 +1,41 @@
+# Manage SELinux related services on EL6 and EL7
+#
+# @param manage_package Manage the `mcstrans` package
+# @param manage_service Manage the `mcstrans` service
+# @param manage_restorecond Manage the `restorecond` service
+# @param package_name The `mcstrans` package name
+# @param service_name The `mcstrans` service name
+# @param package_ensure The ensure status of packages to be installed
+#
+class selinux::mcstrans (
+  # defaults are in module data
+  Boolean $manage_package,
+  Boolean $manage_service,
+  Boolean $manage_restorecond,
+  String  $package_name,
+  String  $service_name,
+  String  $package_ensure = simplib::lookup('simp_options::package_ensure', { 'default_value' => 'installed' }),
+) {
+
+  if $manage_package {
+    package { $package_name: ensure => $package_ensure }
+  }
+
+  if $manage_service {
+    service { $service_name:
+      enable     => true,
+      hasrestart => true,
+      hasstatus  => false,
+      require    => Package[$package_name]
+    }
+  }
+
+  if $manage_restorecond {
+    service { 'restorecond':
+      enable     => true,
+      hasrestart => true,
+      hasstatus  => false
+    }
+  }
+
+}

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "simp-selinux",
-  "version": "2.0.3",
+  "version": "2.1.0",
   "author": "SIMP Team",
   "summary": "manages the SELinux system state",
   "license": "Apache-2.0",
@@ -43,5 +43,6 @@
       "name": "puppet",
       "version_requirement": ">= 4.6.0 < 5.0.0"
     }
-  ]
+  ],
+  "data_provider": "hiera"
 }

--- a/spec/acceptance/nodesets/default.yml
+++ b/spec/acceptance/nodesets/default.yml
@@ -7,17 +7,13 @@ HOSTS:
     platform:   el-7-x86_64
     box:        centos/7
     hypervisor: vagrant
-    vagrant_memsize: 2048
-    yum_repos:
-      simp:
-        baseurl: https://packagecloud.io/simp-project/6_X_Alpha_Dependencies/el/7/$basearch
-        gpgkeys:
-          - https://raw.githubusercontent.com/NationalSecurityAgency/SIMP/master/GPGKEYS/RPM-GPG-KEY-SIMP
-      epel:
-        mirrorlist: 'https://mirrors.fedoraproject.org/metalink?repo=epel-7&arch=$basearch'
-        gpgkeys:
-          - https://getfedora.org/static/352C64E5.txt
-
+  server6:
+    roles:
+      - server
+      - el6
+    platform:   el-6-x86_64
+    box:        centos/6
+    hypervisor: vagrant
 CONFIG:
   log_level: verbose
   type:      aio

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -23,8 +23,8 @@ describe 'selinux' do
             SELINUXTYPE=targeted
             EOF
             ) }
-          it { is_expected.to contain_package('checkpolicy').with(:ensure => 'latest') }
-          it { is_expected.to contain_package('policycoreutils-python').with(:ensure => 'latest') }
+          it { is_expected.to contain_package('checkpolicy').with(:ensure => 'installed') }
+          it { is_expected.to contain_package('policycoreutils-python').with(:ensure => 'installed') }
           it { is_expected.to contain_reboot_notify('selinux') }
         end
 

--- a/spec/classes/mcstrans_spec.rb
+++ b/spec/classes/mcstrans_spec.rb
@@ -1,0 +1,25 @@
+require 'spec_helper'
+
+describe 'selinux::mcstrans' do
+  on_supported_os.each do |os, facts|
+    context "on #{os}" do
+      let(:facts) do
+        facts
+      end
+
+      context 'with default parameters' do
+        it { is_expected.to compile.with_all_deps }
+        it { is_expected.to create_package('mcstrans').with_ensure('installed') }
+
+        if facts[:os][:release][:major].to_i >= 7
+          it { is_expected.to create_service('mcstransd').with_enable(true) }
+          it { is_expected.not_to create_service('restorecond') }
+        else
+          it { is_expected.to create_service('mcstrans').with_enable(true) }
+          it { is_expected.to create_service('restorecond').with_enable(true) }
+        end
+      end
+
+    end
+  end
+end


### PR DESCRIPTION
- Moved management of mcstrans and restorecond to the selinux module
- Change default packages ensure to use the catalyst

SIMP-2684 #close