### PR TITLE
(SIMP-3372) selinux - changelog cleanup as prep for tagging

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,8 +1,9 @@
 * Wed Apr 26 2017 Nick Miller <nick.miller@onyxpoint.com> - 2.1.0-0
 - Moved management of mcstrans and restorecond to the selinux module
 - Change default packages ensure to use the catalyst
+- Update puppet requirement in metadata.json
 
-* Mon Apr 17 2017 Nick Markowski <nmarkowski@keywcorp.com> - 2.0.3-0
+* Mon Apr 17 2017 Nick Markowski <nmarkowski@keywcorp.com> - 2.1.0-0
 - Fixed a bug wherein setenforce would run if selinux was disabled
 - Changes in selinux state incur a reboot notification
 


### PR DESCRIPTION
Last tag was 2.0.2, so changelog entry marked 2.0.3 should be 2.1.0