### PR TITLE
(SIMP-3758) selinux: Add autorelabel feature to type

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -3,5 +3,3 @@ fixtures:
   repositories:
     simplib: https://github.com/simp/pupmod-simp-simplib
     stdlib: https://github.com/simp/puppetlabs-stdlib
-  symlinks:
-    selinux: "#{source_dir}"

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,11 @@ before_script:
 bundler_args: --without development system_tests --path .vendor
 before_install: rm Gemfile.lock || true
 script:
-  - bundle exec rake test
+  - bundle exec rake compare_latest_tag
+  # - bundle exec rake test
+  - bundle exec rake validate
+  - bundle exec rake metadata_lint
+  - bundle exec rake spec
 notifications:
   email: false
 rvm:

--- a/lib/puppet/provider/selinux_state/selinux_state.rb
+++ b/lib/puppet/provider/selinux_state/selinux_state.rb
@@ -1,6 +1,16 @@
 Puppet::Type.type(:selinux_state).provide(:selinux_state) do
+  desc 'Set the SELinux state on the machine, and optionally relabel the filesystem.'
 
   commands :setenforce => '/usr/sbin/setenforce'
+  commands :touch => '/bin/touch'
+
+  def relabel?(should)
+    on_cases  = ['enforcing',:true]
+    off_cases = ['permissive','disabled',:false]
+
+    return true if should == 'permissive' && self.ensure == 'disabled'
+    return(on_cases.include? should) && (off_cases.include? self.ensure)
+  end
 
   def ensure
     return 'disabled' if String(Facter.value(:selinux)) == 'false'
@@ -13,10 +23,15 @@ Puppet::Type.type(:selinux_state).provide(:selinux_state) do
     if String(Facter.value(:selinux)) != 'false'
       case should
         when 'enforcing'
-          setenforce "1"
+          setenforce '1'
         else
-          setenforce "0"
+          setenforce '0'
       end
+    end
+
+    # If we're going from off to on, we should touch /.autorelabel
+    if resource[:autorelabel] && relabel?(should)
+      touch '/.autorelabel'
     end
   end
 end

--- a/lib/puppet/type/selinux_state.rb
+++ b/lib/puppet/type/selinux_state.rb
@@ -1,3 +1,5 @@
+require 'puppet/parameter/boolean'
+
 Puppet::Type.newtype(:selinux_state) do
   @doc = "Toggle the enforcement of selinux"
 
@@ -6,7 +8,15 @@ Puppet::Type.newtype(:selinux_state) do
     desc "An arbitrary, but unique, name for the resource."
   end
 
+  newparam(:autorelabel, :boolean => true, :parent => Puppet::Parameter::Boolean) do
+    desc 'Automatically determine if the filesystem needs to be relabeled.
+      Enforcing > Permissive > Disabled
+    Going up the right requires relabeling.'
+    defaultto 'true'
+  end
+
   newproperty(:ensure) do
+    desc 'Set the SELinux state on the system'
     defaultto(:enforcing)
     newvalues(:false,:true,:disabled,:permissive,:enforcing)
 

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -4,7 +4,8 @@ class selinux::config {
   assert_private()
 
   selinux_state { 'set_selinux_state':
-    ensure => $::selinux::ensure
+    ensure      => $::selinux::ensure,
+    autorelabel => $::selinux::autorelabel
   }
 
   $_enabling  = !$facts['os']['selinux']['enabled'] and member(['enforcing','permissive'],$::selinux::state)

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -8,6 +8,8 @@
 #   The SELinux type you want to enforce.
 #   Note, it is quite possible that 'mls' will render your system inoperable.
 #
+# @param autorelabel Automatically relabel the filesystem if needed
+#
 # @param manage_utils_package
 #   If true, ensure policycoreutils-python is installed. This is a supplemental
 #   package that is required by semanage.
@@ -45,6 +47,7 @@ class selinux (
   Boolean                $manage_restorecond_service,
   String                 $restorecond_package_name,
   Selinux::State         $ensure               = simplib::lookup('simp_options::selinux', { 'default_value' => true }),
+  Boolean                $autorelabel          = false,
   Boolean                $manage_utils_package = true,
   String                 $package_ensure       = simplib::lookup('simp_options::package_ensure', { 'default_value' => 'installed' }),
   Enum['targeted','mls'] $mode                 = 'targeted'

--- a/spec/acceptance/suites/default/00_default_spec.rb
+++ b/spec/acceptance/suites/default/00_default_spec.rb
@@ -22,6 +22,10 @@ describe 'selinux class' do
       it 'should be idempotent' do
         apply_manifest_on(host, manifest, :catch_changes => true)
       end
+
+      describe file('/.autorelabel') do
+        it { should_not exist }
+      end
     end
 
     context 'with simp_options::selinux: false' do
@@ -50,6 +54,9 @@ describe 'selinux class' do
         apply_manifest_on(host, manifest, :catch_changes => true)
       end
 
+      describe file('/.autorelabel') do
+        it { should_not exist }
+      end
     end
 
     context 'when re-enabling selinux after being disabled' do
@@ -66,6 +73,10 @@ describe 'selinux class' do
         expect(status.output).to match(/Disabled/)
       end
 
+      describe file('/.autorelabel') do
+        it { should exist }
+      end
+
       it 'should be enforcing after reboot' do
         host.reboot
 
@@ -78,6 +89,10 @@ describe 'selinux class' do
         # to happen
         apply_manifest_on(host, manifest, :catch_failures => true)
         apply_manifest_on(host, manifest, :catch_changes => true)
+      end
+
+      describe file('/.autorelabel') do
+        it { should_not exist }
       end
     end
   end

--- a/spec/acceptance/suites/default/00_default_spec.rb
+++ b/spec/acceptance/suites/default/00_default_spec.rb
@@ -53,10 +53,11 @@ describe 'selinux class' do
       it 'should be idempotent' do
         apply_manifest_on(host, manifest, :catch_changes => true)
       end
-
-      describe file('/.autorelabel') do
-        it { should_not exist }
-      end
+      
+      # This test will be removed when the system removes this file on it's own
+      # describe file('/.autorelabel') do
+      #   it { should_not exist }
+      # end
     end
 
     context 'when re-enabling selinux after being disabled' do

--- a/spec/unit/puppet/provider/selinux_state/selinux_state_spec.rb
+++ b/spec/unit/puppet/provider/selinux_state/selinux_state_spec.rb
@@ -1,76 +1,76 @@
 require 'spec_helper'
 
 describe Puppet::Type.type(:selinux_state).provider(:selinux_state) do
-
-  let(:provider) { resource.provider }
-  let(:resource) {
-    Puppet::Type.type(:selinux_state).new(
+  before :all  do
+    @resource = Puppet::Type.type(:selinux_state).new(
       name: 'set_selinux_state',
       autorelabel: true
     )
-  }
+
+    @provider = @resource.provider
+  end
 
   describe 'relabel?' do
     context 'enforcing -> enforcing' do
       it 'does not need relabeling' do
-        provider.stubs(:ensure).returns 'enforcing'
-        expect(provider.relabel?('enforcing')).to be_falsey
+        @provider.stubs(:ensure).returns 'enforcing'
+        expect(@provider.relabel?('enforcing')).to be_falsey
       end
     end
 
     context 'enforcing -> permissive' do
       it 'does not need relabeling' do
-        provider.stubs(:ensure).returns 'enforcing'
-        expect(provider.relabel?('permissive')).to be_falsey
+        @provider.stubs(:ensure).returns 'enforcing'
+        expect(@provider.relabel?('permissive')).to be_falsey
       end
     end
 
     context 'enforcing -> disabled' do
       it 'does not need relabeling' do
-        provider.stubs(:ensure).returns 'enforcing'
-        expect(provider.relabel?('disabled')).to be_falsey
+        @provider.stubs(:ensure).returns 'enforcing'
+        expect(@provider.relabel?('disabled')).to be_falsey
       end
     end
 
     context 'permissive -> enforcing' do
       it 'needs relabeling' do
-        provider.stubs(:ensure).returns 'permissive'
-        expect(provider.relabel?('enforcing')).to be_truthy
+        @provider.stubs(:ensure).returns 'permissive'
+        expect(@provider.relabel?('enforcing')).to be_truthy
       end
     end
 
     context 'permissive -> permissive' do
       it 'does not need relabeling' do
-        provider.stubs(:ensure).returns 'permissive'
-        expect(provider.relabel?('permissive')).to be_falsey
+        @provider.stubs(:ensure).returns 'permissive'
+        expect(@provider.relabel?('permissive')).to be_falsey
       end
     end
 
     context 'permissive -> disabled' do
       it 'does not need relabeling' do
-        provider.stubs(:ensure).returns 'permissive'
-        expect(provider.relabel?('disabled')).to be_falsey
+        @provider.stubs(:ensure).returns 'permissive'
+        expect(@provider.relabel?('disabled')).to be_falsey
       end
     end
 
     context 'disabled -> enforcing'do
       it 'needs relabeling' do
-        provider.stubs(:ensure).returns 'disabled'
-        expect(provider.relabel?('enforcing')).to be_truthy
+        @provider.stubs(:ensure).returns 'disabled'
+        expect(@provider.relabel?('enforcing')).to be_truthy
       end
     end
 
     context 'disabled -> permissive'do
       it 'needs relabeling' do
-        provider.stubs(:ensure).returns 'disabled'
-        expect(provider.relabel?('permissive')).to be_truthy
+        @provider.stubs(:ensure).returns 'disabled'
+        expect(@provider.relabel?('permissive')).to be_truthy
       end
     end
 
     context 'disabled -> disabled' do
       it 'does not need relabeling' do
-        provider.stubs(:ensure).returns 'disabled'
-        expect(provider.relabel?('disabled')).to be_falsey
+        @provider.stubs(:ensure).returns 'disabled'
+        expect(@provider.relabel?('disabled')).to be_falsey
       end
     end
   end

--- a/spec/unit/puppet/provider/selinux_state/selinux_state_spec.rb
+++ b/spec/unit/puppet/provider/selinux_state/selinux_state_spec.rb
@@ -1,76 +1,76 @@
 require 'spec_helper'
 
 describe Puppet::Type.type(:selinux_state).provider(:selinux_state) do
-  before :all  do
-    @resource = Puppet::Type.type(:selinux_state).new(
+
+  let(:provider) { resource.provider }
+  let(:resource) {
+    Puppet::Type.type(:selinux_state).new(
       name: 'set_selinux_state',
       autorelabel: true
     )
-
-    @provider = @resource.provider
-  end
+  }
 
   describe 'relabel?' do
     context 'enforcing -> enforcing' do
       it 'does not need relabeling' do
-        @provider.stubs(:ensure).returns 'enforcing'
-        expect(@provider.relabel?('enforcing')).to be_falsey
+        provider.stubs(:ensure).returns 'enforcing'
+        expect(provider.relabel?('enforcing')).to be_falsey
       end
     end
 
     context 'enforcing -> permissive' do
       it 'does not need relabeling' do
-        @provider.stubs(:ensure).returns 'enforcing'
-        expect(@provider.relabel?('permissive')).to be_falsey
+        provider.stubs(:ensure).returns 'enforcing'
+        expect(provider.relabel?('permissive')).to be_falsey
       end
     end
 
     context 'enforcing -> disabled' do
       it 'does not need relabeling' do
-        @provider.stubs(:ensure).returns 'enforcing'
-        expect(@provider.relabel?('disabled')).to be_falsey
+        provider.stubs(:ensure).returns 'enforcing'
+        expect(provider.relabel?('disabled')).to be_falsey
       end
     end
 
     context 'permissive -> enforcing' do
       it 'needs relabeling' do
-        @provider.stubs(:ensure).returns 'permissive'
-        expect(@provider.relabel?('enforcing')).to be_truthy
+        provider.stubs(:ensure).returns 'permissive'
+        expect(provider.relabel?('enforcing')).to be_truthy
       end
     end
 
     context 'permissive -> permissive' do
       it 'does not need relabeling' do
-        @provider.stubs(:ensure).returns 'permissive'
-        expect(@provider.relabel?('permissive')).to be_falsey
+        provider.stubs(:ensure).returns 'permissive'
+        expect(provider.relabel?('permissive')).to be_falsey
       end
     end
 
     context 'permissive -> disabled' do
       it 'does not need relabeling' do
-        @provider.stubs(:ensure).returns 'permissive'
-        expect(@provider.relabel?('disabled')).to be_falsey
+        provider.stubs(:ensure).returns 'permissive'
+        expect(provider.relabel?('disabled')).to be_falsey
       end
     end
 
     context 'disabled -> enforcing'do
       it 'needs relabeling' do
-        @provider.stubs(:ensure).returns 'disabled'
-        expect(@provider.relabel?('enforcing')).to be_truthy
+        provider.stubs(:ensure).returns 'disabled'
+        expect(provider.relabel?('enforcing')).to be_truthy
       end
     end
 
     context 'disabled -> permissive'do
       it 'needs relabeling' do
-        @provider.stubs(:ensure).returns 'disabled'
-        expect(@provider.relabel?('permissive')).to be_truthy
+        provider.stubs(:ensure).returns 'disabled'
+        expect(provider.relabel?('permissive')).to be_truthy
       end
     end
 
     context 'disabled -> disabled' do
       it 'does not need relabeling' do
-        @provider.stubs(:ensure).returns 'disabled'
-        expect(@provider.relabel?('disabled')).to be_falsey
+        provider.stubs(:ensure).returns 'disabled'
+        expect(provider.relabel?('disabled')).to be_falsey
       end
     end
   end

--- a/spec/unit/puppet/provider/selinux_state/selinux_state_spec.rb
+++ b/spec/unit/puppet/provider/selinux_state/selinux_state_spec.rb
@@ -56,14 +56,14 @@ describe Puppet::Type.type(:selinux_state).provider(:selinux_state) do
       end
     end
 
-    context 'disabled -> enforcing'do
+    context 'disabled -> enforcing' do
       it 'needs relabeling' do
         provider.stubs(:ensure).returns 'disabled'
         expect(provider.relabel?('enforcing')).to be_truthy
       end
     end
 
-    context 'disabled -> permissive'do
+    context 'disabled -> permissive' do
       it 'needs relabeling' do
         provider.stubs(:ensure).returns 'disabled'
         expect(provider.relabel?('permissive')).to be_truthy

--- a/spec/unit/puppet/provider/selinux_state/selinux_state_spec.rb
+++ b/spec/unit/puppet/provider/selinux_state/selinux_state_spec.rb
@@ -1,0 +1,77 @@
+require 'spec_helper'
+
+describe Puppet::Type.type(:selinux_state).provider(:selinux_state) do
+
+  let(:provider) { resource.provider }
+  let(:resource) {
+    Puppet::Type.type(:selinux_state).new(
+      name: 'set_selinux_state',
+      autorelabel: true
+    )
+  }
+
+  describe 'relabel?' do
+    context 'enforcing -> enforcing' do
+      it 'does not need relabeling' do
+        provider.stubs(:ensure).returns 'enforcing'
+        expect(provider.relabel?('enforcing')).to be_falsey
+      end
+    end
+
+    context 'enforcing -> permissive' do
+      it 'does not need relabeling' do
+        provider.stubs(:ensure).returns 'enforcing'
+        expect(provider.relabel?('permissive')).to be_falsey
+      end
+    end
+
+    context 'enforcing -> disabled' do
+      it 'does not need relabeling' do
+        provider.stubs(:ensure).returns 'enforcing'
+        expect(provider.relabel?('disabled')).to be_falsey
+      end
+    end
+
+    context 'permissive -> enforcing' do
+      it 'needs relabeling' do
+        provider.stubs(:ensure).returns 'permissive'
+        expect(provider.relabel?('enforcing')).to be_truthy
+      end
+    end
+
+    context 'permissive -> permissive' do
+      it 'does not need relabeling' do
+        provider.stubs(:ensure).returns 'permissive'
+        expect(provider.relabel?('permissive')).to be_falsey
+      end
+    end
+
+    context 'permissive -> disabled' do
+      it 'does not need relabeling' do
+        provider.stubs(:ensure).returns 'permissive'
+        expect(provider.relabel?('disabled')).to be_falsey
+      end
+    end
+
+    context 'disabled -> enforcing'do
+      it 'needs relabeling' do
+        provider.stubs(:ensure).returns 'disabled'
+        expect(provider.relabel?('enforcing')).to be_truthy
+      end
+    end
+
+    context 'disabled -> permissive'do
+      it 'needs relabeling' do
+        provider.stubs(:ensure).returns 'disabled'
+        expect(provider.relabel?('permissive')).to be_truthy
+      end
+    end
+
+    context 'disabled -> disabled' do
+      it 'does not need relabeling' do
+        provider.stubs(:ensure).returns 'disabled'
+        expect(provider.relabel?('disabled')).to be_falsey
+      end
+    end
+  end
+end

--- a/spec/unit/puppet/provider/selinux_state/selinux_state_spec.rb
+++ b/spec/unit/puppet/provider/selinux_state/selinux_state_spec.rb
@@ -2,13 +2,16 @@ require 'spec_helper'
 
 describe Puppet::Type.type(:selinux_state).provider(:selinux_state) do
 
-  let(:provider) { resource.provider }
   let(:resource) {
     Puppet::Type.type(:selinux_state).new(
       name: 'set_selinux_state',
       autorelabel: true
     )
   }
+  let(:provider) {
+    resource.provider
+  }
+
 
   describe 'relabel?' do
     context 'enforcing -> enforcing' do


### PR DESCRIPTION
Adds an autorelabel parameter to the selinux_state provider. This will
touch the /.autorelabel file to systems that are going from selinux
disabled to selinux enabled or permissive.

SIMP-3758 #close