### PR TITLE
(SIMP-3734) Test update for enforce = true

### DIFF
--- a/spec/acceptance/suites/default/00_default_spec.rb
+++ b/spec/acceptance/suites/default/00_default_spec.rb
@@ -12,11 +12,16 @@ describe 'selinux class' do
       let(:hieradata) {{
         'simp_options::selinux' => true,
       }}
+
       it 'should work with no errors and set selinux enforcing' do
         set_hieradata_on(host, hieradata)
         apply_manifest_on(host, manifest, :catch_failures => true)
+
         result = on(host, 'getenforce')
         expect(result.output).to match(/Enforcing/)
+
+        result = on(host, %{source /etc/selinux/config && echo $SELINUX})
+        expect(result.output.strip).to be == 'enforcing'
       end
 
       it 'should be idempotent' do
@@ -54,7 +59,7 @@ describe 'selinux class' do
       it 'should be idempotent' do
         apply_manifest_on(host, manifest, :catch_changes => true)
       end
-      
+
       # This test will be removed when the system removes this file on it's own
       # describe file('/.autorelabel') do
       #   it { should_not exist }


### PR DESCRIPTION
Slight test update to fully test that SELinux enforcement is getting
set to 'enforcing' when 'selinux::enforce' is set to 'true'.

No version bump required - can wait for the next significant change.

SIMP-3734 #close
SIMP-4138 #close
SIMP-4139 #close
SIMP-4140 #close
SIMP-4141 #close