### PR TITLE
(SIMP-3858) Remove simp_options::selinux

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,12 @@
+* Mon Apr 23 2018 Jeanne Greulich <jeanne.greulich@onyxpoint.com> -2.2.0-0
+- simp_options::selinux was supposed to indicate if the selinux module should
+  be included. Class include lists set in the simp module would include selinux  reguardless
+  of this setting.  This option was also being used to set the state of selinux.
+  This caused confusion so  simp_options::selinux setting was removed.
+  The selinux state, set by the ensure parameter, is defaulted to 'enforcing'.
+  This will result in the same behavior as if simp_options::selinux was set to true.
+  See the pupmod-simp-simp module to see which scenarios include selinux by default.
+
 * Thu Dec 07 2017 Steven Pritchard <steven.pritchard@onyxpoint.com> - 2.1.2-0
 - Update README.md from puppet strings
 

--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ This module requires the following:
 
 #### Parameters
 
-* **`ensure`** (`Selinux::State`) *(defaults to: `simplib::lookup('simp_options::selinux', { 'default_value' => true })`)*
+* **`ensure`** (`Selinux::State`) *(defaults to: 'enforcing')*
 
 The state that SELinux should be in. Since you are calling this class, we assume that you want to enforce.
 

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -46,7 +46,7 @@ class selinux (
   Boolean                $manage_restorecond_package,
   Boolean                $manage_restorecond_service,
   String                 $restorecond_package_name,
-  Selinux::State         $ensure               = simplib::lookup('simp_options::selinux', { 'default_value' => true }),
+  Selinux::State         $ensure               = 'enforcing',
   Boolean                $autorelabel          = false,
   Boolean                $manage_utils_package = true,
   String                 $package_ensure       = simplib::lookup('simp_options::package_ensure', { 'default_value' => 'installed' }),

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "simp-selinux",
-  "version": "2.1.2",
+  "version": "2.2.0",
   "author": "SIMP Team",
   "summary": "manages the SELinux system state",
   "license": "Apache-2.0",

--- a/spec/acceptance/suites/default/00_default_spec.rb
+++ b/spec/acceptance/suites/default/00_default_spec.rb
@@ -10,7 +10,7 @@ describe 'selinux class' do
 
     context 'default parameters' do
       let(:hieradata) {{
-        'simp_options::selinux' => true,
+        'selinux::ensure' => true,
       }}
 
       it 'should work with no errors and set selinux enforcing' do
@@ -36,7 +36,7 @@ describe 'selinux class' do
 
     context 'with simp_options::selinux: false' do
       let(:hieradata) {{
-        'simp_options::selinux' => false,
+        'selinux::ensure' => false,
       }}
       it 'should disable selinux, set the current state to permissive, and require reboot' do
         set_hieradata_on(host, hieradata)
@@ -68,7 +68,7 @@ describe 'selinux class' do
 
     context 'when re-enabling selinux after being disabled' do
       let(:hieradata) {{
-        'simp_options::selinux' => true,
+        'selinux::ensure' => true,
       }}
       it 'should work with no errors and set selinux enforcing' do
         set_hieradata_on(host, hieradata)


### PR DESCRIPTION
- simp_options::selinux setting was supposed to control if the
  selinux module was included but was getting over ridden by class
  include statements in other places.  Instead now the local
  parameter, selinux::ensure, is use to set the selinux state and
  is defaulted to 'enforcing'.

SIMP-3858 #comment selinux module updated
SIMP-4531 #close