### PR TITLE
(SIMP-6234) Add kernel support for SELinux

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -1,6 +1,11 @@
 ---
 fixtures:
   repositories:
+    augeas_core:
+      repo: https://github.com/simp/pupmod-puppetlabs-augeas_core.git
+      puppet_version: ">= 6.0.0"
+    augeasproviders_core: https://github.com/simp/augeasproviders_core
+    augeasproviders_grub: https://github.com/simp/augeasproviders_grub
     simplib: https://github.com/simp/pupmod-simp-simplib
     stdlib: https://github.com/simp/puppetlabs-stdlib
     vox_selinux:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -5,13 +5,10 @@
 # https://puppet.com/docs/pe/2018.1/overview/getting_support_for_pe.html
 # ------------------------------------------------------------------------------
 # Release       Puppet   Ruby   EOL
-# SIMP 6.1      4.10.6   2.1.9  TBD
-# SIMP 6.2      4.10.12  2.1.9  TBD
 # SIMP 6.3      5.5.7    2.4.4  TBD***
 # PE 2018.1     5.5.8    2.4.4  2020-05 (LTS)***
 # PE 2019.0     6.0      2.5.1  2019-08-31^^^
 #
-# *** = Modules created for SIMP 6.3+ are not required to support Puppet < 5.5
 # ^^^ = SIMP doesn't support 6 yet; tests are info-only and allowed to fail
 ---
 stages:
@@ -64,18 +61,6 @@ variables:
 
 # Puppet Versions
 #-----------------------------------------------------------------------
-
-.pup_4: &pup_4
-  image: 'ruby:2.1'
-  variables:
-    PUPPET_VERSION: '~> 4.0'
-    MATRIX_RUBY_VERSION: '2.1'
-
-.pup_4_10: &pup_4_10
-  image: 'ruby:2.1'
-  variables:
-    PUPPET_VERSION: '~> 4.10.4'
-    MATRIX_RUBY_VERSION: '2.1'
 
 .pup_5: &pup_5
   image: 'ruby:2.4'
@@ -151,10 +136,6 @@ sanity_checks:
 # Linting
 #-----------------------------------------------------------------------
 
-pup4-lint:
-  <<: *pup_4
-  <<: *lint_tests
-
 pup5-lint:
   <<: *pup_5
   <<: *lint_tests
@@ -174,40 +155,23 @@ pup5.5.7-unit:
   <<: *pup_5_5_7
   <<: *unit_tests
 
-pup4.10-unit:
-  <<: *pup_4_10
-  <<: *unit_tests
-
 pup6-unit:
   <<: *pup_6
   <<: *unit_tests
 
 # Acceptance tests
 # ==============================================================================
-pup4.10:
-  <<: *pup_4_10
-  <<: *acceptance_base
-  script:
-    - 'bundle exec rake beaker:suites'
-
-pup4.10-fips:
-  <<: *pup_4_10
-  <<: *acceptance_base
-  <<: *only_with_SIMP_FULL_MATRIX
-  script:
-    - 'BEAKER_fips=yes bundle exec rake beaker:suites'
-
 pup5.5.7:
   <<: *pup_5_5_7
   <<: *acceptance_base
   script:
-    - 'bundle exec rake beaker:suites'
+    - 'bundle exec rake beaker:suites[default]'
 
 pup5.5.7-fips:
   <<: *pup_5_5_7
   <<: *acceptance_base
   script:
-    - 'BEAKER_fips=yes bundle exec rake beaker:suites'
+    - 'BEAKER_fips=yes bundle exec rake beaker:suites[default]'
 
 pup5.5.7-oel:
   <<: *pup_5_5_7
@@ -227,3 +191,9 @@ pup5.5.7-oel-fips:
 #   <<: *compliance_base
 #   script:
 #     - 'BEAKER_fips=yes bundle exec rake beaker:suites[compliance]'
+
+pup6:
+  <<: *pup_6
+  <<: *acceptance_base
+  script:
+    - 'bundle exec rake beaker:suites[default]'

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,15 +5,12 @@
 # https://puppet.com/docs/pe/2018.1/overview/getting_support_for_pe.html
 # ------------------------------------------------------------------------------
 # Release       Puppet   Ruby   EOL
-# SIMP 6.2      4.10     2.1.9  TBD
-# PE 2016.4     4.10     2.1.9  2018-12-31 (LTS)
-# PE 2017.3     5.3      2.4.4  2018-12-31
-# SIMP 6.3      5.5      2.4.4  TBD***
-# PE 2018.1     5.5      2.4.4  2020-05 (LTS)***
+# PE 2017.3     5.3      2.4.5  2018-12-31
+# SIMP 6.3      5.5      2.4.5  TBD***
+# PE 2018.1     5.5      2.4.5  2020-05 (LTS)***
 # PE 2019.0     6.0      2.5.1  2019-08-31^^^
 #
 # *** = Modules created for SIMP 6.3+ are not required to support Puppet < 5.5
-# ^^^ = SIMP doesn't support 6 yet; tests are info-only and allowed to fail
 
 ---
 language: ruby
@@ -49,7 +46,7 @@ jobs:
   include:
     - stage: check
       name: 'Syntax, style, and validation checks'
-      rvm: 2.4.4
+      rvm: 2.4.5
       env: PUPPET_VERSION="~> 5"
       script:
         - bundle exec rake check:dot_underscore
@@ -62,21 +59,14 @@ jobs:
         - bundle exec puppet module build
 
     - stage: spec
-      name: 'Puppet 4.10 (SIMP 6.2, PE 2016.4)'
-      rvm: 2.1.9
-      env: PUPPET_VERSION="~> 4.10.0"
-      script:
-        - bundle exec rake spec
-
-    - stage: spec
       name: 'Puppet 5.3 (PE 2017.3)'
-      rvm: 2.4.4
+      rvm: 2.4.5
       env: PUPPET_VERSION="~> 5.3.0"
       script:
         - bundle exec rake spec
 
     - stage: spec
-      rvm: 2.4.4
+      rvm: 2.4.5
       name: 'Puppet 5.5 (SIMP 6.3, PE 2018.1)'
       env: PUPPET_VERSION="~> 5.5.0"
       script:
@@ -84,7 +74,7 @@ jobs:
 
     - stage: spec
       name: 'Latest Puppet 5.x'
-      rvm: 2.4.4
+      rvm: 2.4.5
       env: PUPPET_VERSION="~> 5.0"
       script:
         - bundle exec rake spec
@@ -97,7 +87,7 @@ jobs:
         - bundle exec rake spec
 
     - stage: deploy
-      rvm: 2.4.4
+      rvm: 2.4.5
       script:
         - true
       before_deploy:

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,10 @@
+* Fri Apr 05 2019 Trevor Vaughan <tvaughan@onyxpoint.com> - 2.4.0-0
+- Add `selinux::kernel_enforce` for toggling the enforcement of the selinux
+  state at the kernel command line.
+- Switch the /etc/selinux/config template over to EPP format.
+- Deprecate Puppet 4 support
+- Add Puppet 6 support
+
 * Thu Mar 07 2019 Liz Nemsick <lnemsick.simp@gmail.com> - 2.3.1-0
 - Update the upper bound of stdlib to < 6.0.0
 - Update a URL in the README.md

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -3,30 +3,55 @@
 class selinux::config {
   assert_private()
 
+  reboot_notify { 'selinux': reason => 'A reboot is required to modify the selinux state' }
+
   selinux_state { 'set_selinux_state':
-    ensure      => $::selinux::ensure,
-    autorelabel => $::selinux::autorelabel
+    ensure      => $selinux::ensure,
+    autorelabel => $selinux::autorelabel,
+    notify      => Reboot_notify['selinux']
   }
 
-  $_enabling  = !$facts['selinux'] and member(['enforcing','permissive'], $::selinux::state)
-  $_disabling = $facts['selinux'] and !member(['enforcing','permissive'], $::selinux::state)
+  $_enabling  = !$facts['selinux'] and member(['enforcing','permissive'], $selinux::state)
+  $_disabling = $facts['selinux'] and !member(['enforcing','permissive'], $selinux::state)
 
-  if $_enabling or $_disabling {
-    reboot_notify { 'selinux':
-      reason    => 'A reboot is required to completely modify selinux state',
-      subscribe => Selinux_state['set_selinux_state']
+  if $selinux::kernel_enforce {
+    if $selinux::state == 'disabled' {
+      kernel_parameter { 'selinux':
+        value  => '0',
+        notify => Reboot_notify['selinux']
+      }
+    }
+    else {
+      kernel_parameter { 'selinux':
+        value  => '1',
+        notify => Reboot_notify['selinux']
+      }
+
+      if ( $selinux::state == 'permissive' ) {
+        kernel_parameter { 'enforcing':
+          value  => '0',
+          notify => Reboot_notify['selinux']
+        }
+      }
+      else {
+        kernel_parameter { 'enforcing':
+          value  => '1',
+          notify => Reboot_notify['selinux']
+        }
+      }
     }
   }
-
-  # These vars are used in the template below
-  $_state = $::selinux::state
-  $_mode = $::selinux::mode
 
   file { '/etc/selinux/config':
     ensure  => 'file',
     owner   => 'root',
     group   => 'root',
     mode    => '0644',
-    content => template('selinux/sysconfig.erb')
+    content => epp("${module_name}/etc/selinux/config",
+      {
+        state => $selinux::state,
+        mode  => $selinux::mode
+      }
+    )
   }
 }

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -35,6 +35,9 @@
 # @param restorecond_package_name
 #   The `restorecond` package name.
 #
+# @param kernel_enforce
+#   Add the SELinux settings to the default kernel settings.
+
 # @param package_ensure The ensure status of packages to be installed
 #
 # @param login_resources
@@ -61,6 +64,7 @@ class selinux (
   Boolean                $manage_restorecond_service,
   String                 $restorecond_package_name,
   Selinux::State         $ensure                      = 'enforcing',
+  Boolean                $kernel_enforce              = false,
   Boolean                $autorelabel                 = false,
   Boolean                $manage_utils_package        = true,
   String                 $package_ensure              = simplib::lookup('simp_options::package_ensure', { 'default_value' => 'installed' }),

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "simp-selinux",
-  "version": "2.3.1",
+  "version": "2.4.0",
   "author": "SIMP Team",
   "summary": "manages the SELinux system state",
   "license": "Apache-2.0",
@@ -52,7 +52,7 @@
   "requirements": [
     {
       "name": "puppet",
-      "version_requirement": ">= 4.10.4 < 6.0.0"
+      "version_requirement": ">= 5.0.0 < 7.0.0"
     }
   ]
 }

--- a/spec/acceptance/suites/default/00_default_spec.rb
+++ b/spec/acceptance/suites/default/00_default_spec.rb
@@ -43,6 +43,8 @@ describe 'selinux class' do
 
         result = on(host, %{source /etc/selinux/config && echo $SELINUX})
         expect(result.output.strip).to be == 'enforcing'
+
+        host.reboot
       end
 
       it 'should be idempotent' do
@@ -58,7 +60,7 @@ describe 'selinux class' do
         set_hieradata_on(host, hieradata)
         agent_output = apply_manifest_on(host, manifest, :catch_failures => true)
         expect(agent_output.stdout).to match(/ensure changed 'enforcing' to 'disabled'/)
-        expect(agent_output.stdout).to match(/System Reboot Required Because:\n\s+selinux => A reboot is required to completely modify selinux state/)
+        expect(agent_output.stdout).to match(/System Reboot Required Because:\n\s+selinux => A reboot is required to modify the selinux state/)
         status = on(host, 'getenforce')
         expect(status.output).to match(/Permissive/)
         # This will not be idempotent until after reboot since the system will
@@ -85,7 +87,7 @@ describe 'selinux class' do
         set_hieradata_on(host, hieradata)
         agent_output = apply_manifest_on(host, manifest, :catch_failures => true)
         expect(agent_output.stdout).to match(/ensure changed 'disabled' to 'enforcing'/)
-        expect(agent_output.stdout).to match(/System Reboot Required Because:\n\s+selinux => A reboot is required to completely modify selinux state/)
+        expect(agent_output.stdout).to match(/System Reboot Required Because:\n\s+selinux => A reboot is required to modify the selinux state/)
         status = on(host, 'getenforce')
         # Won't take effect until after reboot
         expect(status.output).to match(/Disabled/)

--- a/spec/acceptance/suites/default/05_kernel_enforce_spec.rb
+++ b/spec/acceptance/suites/default/05_kernel_enforce_spec.rb
@@ -1,0 +1,38 @@
+require 'spec_helper_acceptance'
+
+test_name 'selinux class kernel enforcement'
+
+describe 'selinux class kernel enforcement' do
+  hosts.each do |host|
+
+    let(:manifest) { "include 'selinux'" }
+
+    context 'kernel enforcing' do
+      let(:hieradata) {{
+        'selinux::ensure'         => true,
+        'selinux::kernel_enforce' => true
+      }}
+
+      it 'should work with no errors and set selinux enforcing' do
+        set_hieradata_on(host, hieradata)
+        apply_manifest_on(host, manifest, :catch_failures => true)
+
+        host.reboot
+
+        result = on(host, 'cat /proc/cmdline').output.strip
+        result = Hash[result.split(/\s+/).grep(/=/).map{|x|
+          # Some RHS entries can contain '='
+          y = x.split('=')
+          [y[0], y[1..-1].join('=')]
+        }]
+
+        expect(result['selinux']).to eq('1')
+        expect(result['enforcing']).to eq('1')
+      end
+
+      it 'should be idempotent' do
+        apply_manifest_on(host, manifest, :catch_changes => true)
+      end
+    end
+  end
+end

--- a/templates/etc/selinux/config.epp
+++ b/templates/etc/selinux/config.epp
@@ -1,10 +1,14 @@
+<%- |
+  String[1] $state,
+  String[1] $mode
+| -%>
 # This file controls the state of SELinux on the system.
 # SELINUX= can take one of these three values:
 # enforcing - SELinux security policy is enforced.
 # permissive - SELinux prints warnings instead of enforcing.
 # disabled - SELinux is fully disabled.
-SELINUX=<%= @_state %>
+SELINUX=<%= $state %>
 # SELINUXTYPE= type of policy in use. Possible values are:
 # targeted - Only targeted network daemons are protected.
 # strict - Full SELinux protection.
-SELINUXTYPE=<%= @_mode %>
+SELINUXTYPE=<%= $mode %>


### PR DESCRIPTION
- Add `selinux::kernel_enforce` for toggling the enforcement of the selinux
  state at the kernel command line.
- Switch the /etc/selinux/config template over to EPP format.
- Deprecate Puppet 4 support
- Add Puppet 6 support

SIMP-6234 #close