### PR TITLE
(SIMP-6243) selinux::login_resources deep merge

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,7 @@
+* Fri Jun 14 2019 Trevor Vaughan <tvaughan@onyxpoint.com> - 2.4.1-0
+- Ensure that the selinux::login_resources Hash performs a deep merge by
+  default.
+
 * Fri Apr 05 2019 Trevor Vaughan <tvaughan@onyxpoint.com> - 2.4.0-0
 - Add `selinux::kernel_enforce` for toggling the enforcement of the selinux
   state at the kernel command line.

--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -5,10 +5,10 @@
 
 **Classes**
 
-* [`selinux`](#selinux): Manage active SELinux state and state after a reboot
-* [`selinux::config`](#selinuxconfig): This class sets selinux system parameters
+* [`selinux`](#selinux): 
+* [`selinux::config`](#selinuxconfig): Set global SELinux system parameters
 * [`selinux::install`](#selinuxinstall): Install selinux-related packages not managed by vox_selinux
-* [`selinux::service`](#selinuxservice): Ensures mcstrans and restorecond services are running, as appropriate
+* [`selinux::service`](#selinuxservice): Ensures mcstrans and restorecond services managed
 
 **Resource types**
 
@@ -19,88 +19,11 @@
 
 ### selinux
 
-Manage active SELinux state and state after a reboot
+The selinux class.
 
 #### Parameters
 
 The following parameters are available in the `selinux` class.
-
-##### `ensure`
-
-Data type: `Selinux::State`
-
-The state that SELinux should be in.
-Since you are calling this class, we assume that you want to enforce.
-
-Default value: 'enforcing'
-
-##### `mode`
-
-Data type: `Enum['targeted','mls']`
-
-The SELinux type you want to enforce.
-Note, it is quite possible that 'mls' will render your system inoperable.
-
-Default value: 'targeted'
-
-##### `autorelabel`
-
-Data type: `Boolean`
-
-Automatically relabel the filesystem if needed
-
-Default value: `false`
-
-##### `manage_utils_package`
-
-Data type: `Boolean`
-
-If true, ensure policycoreutils-python is installed. This is a supplemental
-package that is required by semanage.
-
-Default value: `true`
-
-##### `manage_mcstrans_package`
-
-Data type: `Boolean`
-
-Manage the `mcstrans` package.
-
-##### `manage_mcstrans_service`
-
-Data type: `Boolean`
-
-Manage the `mcstrans` service.
-
-##### `mcstrans_service_name`
-
-Data type: `String`
-
-The `mcstrans` service name.
-
-##### `mcstrans_package_name`
-
-Data type: `String`
-
-The `mcstrans` package name.
-
-##### `manage_restorecond_package`
-
-Data type: `Boolean`
-
-Manage the `restorecond` package.
-
-##### `manage_restorecond_service`
-
-Data type: `Boolean`
-
-Manage the `restorecond` service.
-
-##### `restorecond_package_name`
-
-Data type: `String`
-
-The `restorecond` package name.
 
 ##### `package_ensure`
 
@@ -117,6 +40,9 @@ Data type: `Optional[Hash]`
 A hash of resources that should be created on the system as expected by
 `create_resources()` called on the `selinux_login` type
 
+A deep merge strategy is used when performing APL lookups on this value by
+default.
+
 @example Change __default__ to user_u
   ---
   selinux::login_resources:
@@ -129,9 +55,91 @@ A hash of resources that should be created on the system as expected by
 
 Default value: `undef`
 
+##### `manage_mcstrans_package`
+
+Data type: `Boolean`
+
+
+
+##### `manage_mcstrans_service`
+
+Data type: `Boolean`
+
+
+
+##### `mcstrans_package_name`
+
+Data type: `String`
+
+
+
+##### `mcstrans_service_name`
+
+Data type: `String`
+
+
+
+##### `manage_restorecond_package`
+
+Data type: `Boolean`
+
+
+
+##### `manage_restorecond_service`
+
+Data type: `Boolean`
+
+
+
+##### `restorecond_package_name`
+
+Data type: `String`
+
+
+
+##### `ensure`
+
+Data type: `Selinux::State`
+
+
+
+Default value: 'enforcing'
+
+##### `kernel_enforce`
+
+Data type: `Boolean`
+
+
+
+Default value: `false`
+
+##### `autorelabel`
+
+Data type: `Boolean`
+
+
+
+Default value: `false`
+
+##### `manage_utils_package`
+
+Data type: `Boolean`
+
+
+
+Default value: `true`
+
+##### `mode`
+
+Data type: `Enum['targeted','mls']`
+
+
+
+Default value: 'targeted'
+
 ### selinux::config
 
-This class sets selinux system parameters
+Set global SELinux system parameters
 
 ### selinux::install
 
@@ -139,8 +147,7 @@ Install selinux-related packages not managed by vox_selinux
 
 ### selinux::service
 
-Ensures mcstrans and restorecond services are running,
-as appropriate
+Ensures mcstrans and restorecond services managed
 
 ## Resource types
 

--- a/data/common.yaml
+++ b/data/common.yaml
@@ -1,4 +1,10 @@
 ---
+lookup_options:
+  selinux::login_resources:
+    merge:
+      stragety: deep
+      knockout_prefix: --
+
 selinux::manage_mcstrans_package: true
 selinux::manage_mcstrans_service: true
 selinux::mcstrans_package_name: mcstrans

--- a/data/common.yaml
+++ b/data/common.yaml
@@ -2,7 +2,7 @@
 lookup_options:
   selinux::login_resources:
     merge:
-      stragety: deep
+      strategy: deep
       knockout_prefix: --
 
 selinux::manage_mcstrans_package: true

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -1,4 +1,4 @@
-# This class sets selinux system parameters
+# @summary Set global SELinux system parameters
 #
 class selinux::config {
   assert_private()

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -1,4 +1,4 @@
-# Manage active SELinux state and state after a reboot
+# @summary Manage active SELinux state and state after a reboot
 #
 # @param ensure
 #   The state that SELinux should be in.
@@ -43,6 +43,9 @@
 # @param login_resources
 #   A hash of resources that should be created on the system as expected by
 #   `create_resources()` called on the `selinux_login` type
+#
+#   A deep merge strategy is used when performing APL lookups on this value by
+#   default.
 #
 #   @example Change __default__ to user_u
 #     ---

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -1,4 +1,4 @@
-# Install selinux-related packages not managed by vox_selinux
+# @summary Install selinux-related packages not managed by vox_selinux
 #
 class selinux::install {
   assert_private()

--- a/manifests/service.pp
+++ b/manifests/service.pp
@@ -1,5 +1,4 @@
-# Ensures mcstrans and restorecond services are running,
-# as appropriate
+# @summary Ensures mcstrans and restorecond services managed
 #
 class selinux::service {
   assert_private()

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "simp-selinux",
-  "version": "2.4.0",
+  "version": "2.4.1",
   "author": "SIMP Team",
   "summary": "manages the SELinux system state",
   "license": "Apache-2.0",


### PR DESCRIPTION
The selinux::login_resources Hash should have performed a deep merge by
default so that users could add to it as necessary.

SIMP-6243 #close