### PR TITLE
(SIMP-8696) Make selinux::install independent

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,9 @@
+* Wed Nov 18 2020 Trevor Vaughan <tvaughan@onyxpoint.com> - 2.6.1-0
+- Allow users to include `selinux::install` without needing full SELinux system
+  management. This is particularly important when the native types are to be
+  used in different modules but you don't want to include full management just
+  to get the required packages.
+
 * Mon Sep 21 2020 Trevor Vaughan <tvaughan@onyxpoint.com> - 2.6.0-0
 - No longer enable or install mcstransd by default
   - It is a user convenience feature and not required for core functionality

--- a/Gemfile
+++ b/Gemfile
@@ -5,7 +5,7 @@ ENV['PDK_DISABLE_ANALYTICS'] ||= 'true'
 gem_sources.each { |gem_source| source gem_source }
 
 group :test do
-  puppet_version = ENV['PUPPET_VERSION'] || '~> 5.5'
+  puppet_version = ENV['PUPPET_VERSION'] || '~> 6.18'
   major_puppet_version = puppet_version.scan(/(\d+)(?:\.|\Z)/).flatten.first.to_i
   gem 'rake'
   gem 'puppet', puppet_version

--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -36,7 +36,7 @@ Data type: `String`
 
 The ensure status of packages to be installed
 
-Default value: `simplib::lookup('simp_options::package_ensure', { 'default_value' => 'installed' })`
+Default value: `simplib::lookup('simp_options::package_ensure', { 'default_value' => 'present' })`
 
 ##### `login_resources`
 
@@ -151,6 +151,66 @@ Set global SELinux system parameters
 ### `selinux::install`
 
 Install selinux-related packages not managed by vox_selinux
+
+#### Parameters
+
+The following parameters are available in the `selinux::install` class.
+
+##### `manage_utils_package`
+
+Data type: `Boolean`
+
+
+
+Default value: `pick(getvar('selinux::manage_utils_package'), true)`
+
+##### `utils_packages`
+
+Data type: `Array[String]`
+
+
+
+Default value: `['checkpolicy']`
+
+##### `manage_mcstrans_package`
+
+Data type: `Boolean`
+
+
+
+Default value: `simplib::lookup('selinux::manage_mcstrans_package')`
+
+##### `mcstrans_package_name`
+
+Data type: `String`
+
+
+
+Default value: `simplib::lookup('selinux::mcstrans_package_name')`
+
+##### `manage_restorecond_package`
+
+Data type: `Boolean`
+
+
+
+Default value: `simplib::lookup('selinux::manage_restorecond_package')`
+
+##### `restorecond_package_name`
+
+Data type: `String`
+
+
+
+Default value: `simplib::lookup('selinux::restorecond_package_name')`
+
+##### `package_ensure`
+
+Data type: `String`
+
+
+
+Default value: `simplib::lookup('selinux::package_ensure', { 'default_value' => simplib::lookup('simp_options::package_ensure', { 'default_value' => 'present' } ) } )`
 
 ### `selinux::service`
 

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -72,7 +72,7 @@ class selinux (
   Boolean                $kernel_enforce              = false,
   Boolean                $autorelabel                 = false,
   Boolean                $manage_utils_package        = true,
-  String                 $package_ensure              = simplib::lookup('simp_options::package_ensure', { 'default_value' => 'installed' }),
+  String                 $package_ensure              = simplib::lookup('simp_options::package_ensure', { 'default_value' => 'present' }),
   Enum['targeted','mls'] $mode                        = 'targeted',
   Optional[Hash]         $login_resources             = undef
 ) {

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -1,21 +1,23 @@
 # @summary Install selinux-related packages not managed by vox_selinux
 #
-class selinux::install {
-  assert_private()
-
-  $utils_packages = [
-    'checkpolicy'
-  ]
-
-  if $selinux::manage_utils_package {
-    ensure_resource('package', $utils_packages, { 'ensure' => $selinux::package_ensure })
+class selinux::install (
+  Boolean       $manage_utils_package       = pick(getvar('selinux::manage_utils_package'), true),
+  Array[String] $utils_packages             = ['checkpolicy'],
+  Boolean       $manage_mcstrans_package    = simplib::lookup('selinux::manage_mcstrans_package'),
+  String        $mcstrans_package_name      = simplib::lookup('selinux::mcstrans_package_name'),
+  Boolean       $manage_restorecond_package = simplib::lookup('selinux::manage_restorecond_package'),
+  String        $restorecond_package_name   = simplib::lookup('selinux::restorecond_package_name'),
+  String        $package_ensure             = simplib::lookup('selinux::package_ensure', { 'default_value' => simplib::lookup('simp_options::package_ensure', { 'default_value' => 'present' } ) } )
+){
+  if $manage_utils_package {
+    ensure_packages($utils_packages, { 'ensure' =>  $package_ensure})
   }
 
-  if $selinux::manage_mcstrans_package {
-    package { $selinux::mcstrans_package_name: ensure => $selinux::package_ensure }
+  if $manage_mcstrans_package {
+    ensure_packages([$mcstrans_package_name], { 'ensure' =>  $package_ensure})
   }
 
-  if $selinux::manage_restorecond_package {
-    package { $selinux::restorecond_package_name: ensure => $selinux::package_ensure }
+  if $manage_restorecond_package {
+    ensure_packages([$restorecond_package_name], { 'ensure' =>  $package_ensure})
   }
 }

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "simp-selinux",
-  "version": "2.6.0",
+  "version": "2.6.1",
   "author": "SIMP Team",
   "summary": "manages the SELinux system state",
   "license": "Apache-2.0",

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -30,7 +30,7 @@ describe 'selinux' do
           SELINUXTYPE=targeted
           EOF
           ) }
-        it { is_expected.to contain_package('checkpolicy').with(ensure: 'installed') }
+        it { is_expected.to contain_package('checkpolicy').with(ensure: 'present') }
         it { is_expected.not_to contain_package('mcstrans') }
         it { is_expected.not_to contain_service('mcstransd') }
 
@@ -38,7 +38,7 @@ describe 'selinux' do
           it { is_expected.not_to contain_package(policycoreutils_package) }
           it { is_expected.not_to create_service('restorecond') }
         else
-          it { is_expected.to contain_package(policycoreutils_package).with(ensure: 'installed') }
+          it { is_expected.to contain_package(policycoreutils_package).with(ensure: 'present') }
           it { is_expected.to create_service('restorecond').with({
             enable: true,
             ensure: 'running'
@@ -54,7 +54,7 @@ describe 'selinux' do
           }
         end
 
-        it { is_expected.to contain_package('mcstrans').with(ensure: 'installed') }
+        it { is_expected.to contain_package('mcstrans').with(ensure: 'present') }
 
         it { is_expected.to create_service(mcstrans_service).with({
             enable: true,
@@ -151,7 +151,7 @@ describe 'selinux' do
           EOF
           ) }
 
-        it { is_expected.to contain_package(policycoreutils_package).with(ensure: 'installed') }
+        it { is_expected.to contain_package(policycoreutils_package).with(ensure: 'present') }
 
         it { is_expected.to create_service('restorecond').with(
           enable: true,

--- a/spec/classes/install_spec.rb
+++ b/spec/classes/install_spec.rb
@@ -1,0 +1,38 @@
+require 'spec_helper'
+
+describe 'selinux::install' do
+  on_supported_os.each do |os, os_facts|
+    context "on #{os}" do
+      let(:facts) do
+        os_facts
+      end
+
+      let(:mcstrans_service) do
+        os_facts[:os][:release][:major].to_i >= 7 ? 'mcstransd' : 'mcstrans'
+      end
+
+      let(:policycoreutils_package) do
+        os_facts[:os][:release][:major].to_i >= 7 ? 'policycoreutils-restorecond' : 'policycoreutils'
+      end
+
+      it { is_expected.to contain_package('checkpolicy').with(ensure: 'present') }
+      it { is_expected.not_to contain_package('mcstrans') }
+
+      if os_facts[:os][:release][:major].to_i >= 7
+        it { is_expected.not_to contain_package(policycoreutils_package) }
+      else
+        it { is_expected.to contain_package(policycoreutils_package).with(ensure: 'present') }
+      end
+
+      context 'when managing mcstrans' do
+        let(:params) do
+          {
+            :manage_mcstrans_package => true,
+          }
+        end
+
+        it { is_expected.to contain_package('mcstrans').with(ensure: 'present') }
+      end
+    end
+  end
+end


### PR DESCRIPTION
Fixed:
  - Allow users to include `selinux::install` without needing full
    SELinux system management. This is particularly important when the
    native types are to be used in different modules but you don't want
    to include full management just to get the required packages.

SIMP-8696 #comment Make selinux::install independently usable