### PR TITLE
(SIMP-8701) Uses selinux_login resources when selinux disabled

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,9 @@
+* Fri Nov 20 2020 Liz Nemsick <lnemsick.simp@gmail.com> - 2.6.2-0
+- Fixed a bug in which the module would attempt to create `selinux_login`
+  resources when `selinux::login_resources` was set but selinux was disabled.
+  This resulted in an error message 'Could not find a suitable provider
+  for selinux_login' during catalog compilation.
+
 * Wed Nov 18 2020 Trevor Vaughan <tvaughan@onyxpoint.com> - 2.6.1-0
 - Allow users to include `selinux::install` without needing full SELinux system
   management. This is particularly important when the native types are to be

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -94,6 +94,8 @@ class selinux (
   -> Class['vox_selinux']
 
   if $login_resources {
-    create_resources('selinux_login', $login_resources)
+    if $facts['selinux_current_mode'] and ($facts['selinux_current_mode'] != 'disabled') {
+      create_resources('selinux_login', $login_resources)
+    }
   }
 }

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "simp-selinux",
-  "version": "2.6.1",
+  "version": "2.6.2",
   "author": "SIMP Team",
   "summary": "manages the SELinux system state",
   "license": "Apache-2.0",


### PR DESCRIPTION
Fixed a bug in which the module would attempt to create `selinux_login`
resources when `selinux::login_resources` was set but selinux was disabled.
This resulted in an error message 'Could not find a suitable provider
for selinux_login' during catalog compilation.

SIMP-8701 #close