### PR TITLE
Update deps to use puppet/systemd

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -13,7 +13,9 @@ fixtures:
     simp_options: https://github.com/simp/pupmod-simp-simp_options.git
     simplib: https://github.com/simp/pupmod-simp-simplib.git
     stdlib: https://github.com/simp/puppetlabs-stdlib.git
-    systemd: https://github.com/simp/puppet-systemd.git
+    systemd:
+      repo: https://github.com/simp/puppet-systemd.git
+      branch: simp-master
     vox_selinux:
       repo: https://github.com/simp/pupmod-voxpupuli-selinux.git
       branch: simp-master

--- a/.gitignore
+++ b/.gitignore
@@ -9,7 +9,12 @@
 .idea/
 dist
 /pkg
-/spec/fixtures
+# Read everything in fixtures
+/spec/fixtures/*
+# Un-ignore hieradata
+!/spec/fixtures/hieradata/*
+# Except this one, which is auto-generated
+/spec/fixtures/hieradata/hiera.yaml
 /spec/rp_env
 /.rspec_system
 /.vagrant

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,6 @@
+* Fri Jun 03 2022 Chris Tessmer <chris.tessmer@onyxpoint.com> - 2.8.0
+- Update from camptocamp/systemd to puppet/systemd
+
 * Wed Jun 16 2021 Chris Tessmer <chris.tessmer@onyxpoint.com> - 2.7.0
 - Removed support for Puppet 5
 - Ensured support for Puppet 7 in requirements and stdlib

--- a/manifests/service.pp
+++ b/manifests/service.pp
@@ -21,12 +21,11 @@ class selinux::service {
         $_proc_gid = $facts.dig('simplib__mountpoints', '/proc', 'options_hash', 'gid')
 
         if $_proc_gid {
-          simplib::assert_optional_dependency($module_name, 'camptocamp/systemd')
+          simplib::assert_optional_dependency($module_name, 'puppet/systemd')
 
           systemd::dropin_file { "${module_name}_mcstransd_hidepid_add_gid.conf":
             unit          => "${selinux::mcstrans_service_name}.service",
             notify        => Service[$selinux::mcstrans_service_name],
-            daemon_reload => 'eager',
             content       => @("SYSTEMD_OVERRIDE")
               [Service]
               SupplementaryGroups=${_proc_gid}

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "simp-selinux",
-  "version": "2.7.0",
+  "version": "2.8.0",
   "author": "SIMP Team",
   "summary": "manages the SELinux system state",
   "license": "Apache-2.0",
@@ -29,8 +29,8 @@
   "simp": {
     "optional_dependencies": [
       {
-        "name": "camptocamp/systemd",
-        "version_requirement": ">= 2.2.0 < 3.0.0"
+        "name": "puppet/systemd",
+        "version_requirement": ">= 3.0.0 < 4.0.0"
       }
     ]
   },

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -30,7 +30,7 @@ describe 'selinux' do
           SELINUXTYPE=targeted
           EOF
           ) }
-        it { is_expected.to contain_package('checkpolicy').with(ensure: 'present') }
+        it { is_expected.to contain_package('checkpolicy').with_ensure(/\A(present|installed)\Z/) }
         it { is_expected.not_to contain_package('mcstrans') }
         it { is_expected.not_to contain_service('mcstransd') }
 
@@ -38,7 +38,7 @@ describe 'selinux' do
           it { is_expected.not_to contain_package(policycoreutils_package) }
           it { is_expected.not_to create_service('restorecond') }
         else
-          it { is_expected.to contain_package(policycoreutils_package).with(ensure: 'present') }
+          it { is_expected.to contain_package(policycoreutils_package).with_ensure(/\A(present|installed)\Z/) }
           it { is_expected.to create_service('restorecond').with({
             enable: true,
             ensure: 'running'
@@ -54,7 +54,7 @@ describe 'selinux' do
           }
         end
 
-        it { is_expected.to contain_package('mcstrans').with(ensure: 'present') }
+        it { is_expected.to contain_package('mcstrans').with_ensure(/\A(present|installed)\Z/) }
 
         it { is_expected.to create_service(mcstrans_service).with({
             enable: true,
@@ -151,7 +151,7 @@ describe 'selinux' do
           EOF
           ) }
 
-        it { is_expected.to contain_package(policycoreutils_package).with(ensure: 'present') }
+        it { is_expected.to contain_package(policycoreutils_package).with_ensure(/\A(present|installed)\Z/) }
 
         it { is_expected.to create_service('restorecond').with(
           enable: true,

--- a/spec/classes/install_spec.rb
+++ b/spec/classes/install_spec.rb
@@ -15,7 +15,7 @@ describe 'selinux::install' do
         os_facts[:os][:release][:major].to_i >= 7 ? 'policycoreutils-restorecond' : 'policycoreutils'
       end
 
-      it { is_expected.to contain_package('checkpolicy').with(ensure: 'present') }
+      it { is_expected.to contain_package('checkpolicy').with(ensure: /\A(present|installed)\Z/) }
       it { is_expected.not_to contain_package('mcstrans') }
 
       if os_facts[:os][:release][:major].to_i >= 7
@@ -31,7 +31,7 @@ describe 'selinux::install' do
           }
         end
 
-        it { is_expected.to contain_package('mcstrans').with(ensure: 'present') }
+        it { is_expected.to contain_package('mcstrans').with_ensure(/A(present|installed)Z/) }
       end
     end
   end

--- a/spec/classes/install_spec.rb
+++ b/spec/classes/install_spec.rb
@@ -31,7 +31,7 @@ describe 'selinux::install' do
           }
         end
 
-        it { is_expected.to contain_package('mcstrans').with_ensure(/A(present|installed)Z/) }
+        it { is_expected.to contain_package('mcstrans').with_ensure(/\A(present|installed)\Z/) }
       end
     end
   end


### PR DESCRIPTION
This patch updates from camptocamp/systemd 2.x to puppet/systemd 3.x

This bump is driven by simp/simp-core#829