### PR TITLE
Add RockyLinux 8 support

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -13,9 +13,7 @@ fixtures:
     simp_options: https://github.com/simp/pupmod-simp-simp_options.git
     simplib: https://github.com/simp/pupmod-simp-simplib.git
     stdlib: https://github.com/simp/puppetlabs-stdlib.git
-    systemd:
-      repo: https://github.com/simp/puppet-systemd.git
-      branch: simp-master
+    systemd: https://github.com/simp/puppet-systemd.git
     vox_selinux:
       repo: https://github.com/simp/pupmod-voxpupuli-selinux.git
       branch: simp-master

--- a/.github/workflows/pr_tests.yml
+++ b/.github/workflows/pr_tests.yml
@@ -109,14 +109,16 @@ jobs:
     strategy:
       matrix:
         puppet:
-          - label: 'Puppet 7.x'
-            puppet_version: '~> 7.21.0'
+          - label: 'Puppet 7.x [SIMP 6.6/PE 2021.7]'
+            puppet_version: '~> 7.0'
             ruby_version: '2.7'
+            experimental: false
           - label: 'Puppet 8.x'
             puppet_version: '~> 8.0'
-            ruby_version: '3.2'
+            ruby_version: 3.1
+            experimental: true
     env:
-      PUPPET_VERSION: '${{matrix.puppet.puppet_version}}'
+      PUPPET_VERSION: ${{matrix.puppet.puppet_version}}
     steps:
       - uses: actions/checkout@v3
       - name: 'Install Ruby ${{matrix.puppet.ruby_version}}'
@@ -126,6 +128,7 @@ jobs:
           bundler-cache: true
       - run: 'command -v rpm || if command -v apt-get; then sudo apt-get update; sudo apt-get install -y rpm; fi ||:'
       - run: 'bundle exec rake spec'
+        continue-on-error: ${{matrix.puppet.experimental}}
 
 #  dump_contexts:
 #    name: 'Examine Context contents'

--- a/.puppet-lint.rc
+++ b/.puppet-lint.rc
@@ -9,7 +9,7 @@
 --no-class_inherits_from_params_class-check
 --no-140chars-check
 --no-trailing_comma-check
---no-empty_string_assignment-check
+--no-params-empty-string-assignment-check
 # This is here because the code can't handle lookups in parameters and SIMP
 # modules have a LOT of those
 --no-parameter_order-check

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,6 @@
+* Mon Jun 12 2023 Chris Tessmer <chris.tessmer@onyxpoint.com> - 2.9.0
+- Add RockyLinux 8 support
+
 * Mon Jan 23 2023 Michael Riddle <mike@sicura.us> - 2.8.1
 - Added RHEL 9 support
 

--- a/Gemfile
+++ b/Gemfile
@@ -21,7 +21,6 @@ group :test do
   gem 'puppetlabs_spec_helper'
   gem 'metadata-json-lint'
   gem 'puppet-strings'
-  gem 'puppet-lint-empty_string-check',   :require => false
   gem 'puppet-lint-trailing_comma-check', :require => false
   gem 'simp-rspec-puppet-facts', ENV['SIMP_RSPEC_PUPPET_FACTS_VERSION'] || '~> 3.1'
   gem 'simp-rake-helpers', ENV['SIMP_RAKE_HELPERS_VERSION'] || ['>= 5.12.1', '< 6']

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -11,8 +11,8 @@ class selinux::config {
     notify      => Reboot_notify['selinux']
   }
 
-  $_enabling  = !$facts['selinux'] and member(['enforcing','permissive'], $selinux::state)
-  $_disabling = $facts['selinux'] and !member(['enforcing','permissive'], $selinux::state)
+  $_enabling  = !$facts['os']['selinux']['enabled'] and member(['enforcing','permissive'], $selinux::state)
+  $_disabling = $facts['os']['selinux']['enabled'] and !member(['enforcing','permissive'], $selinux::state)
 
   if $selinux::kernel_enforce {
     if $selinux::state == 'disabled' {

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -93,7 +93,7 @@ class selinux (
   ~> Class['selinux::service']
 
   if $login_resources {
-    if $facts['selinux_current_mode'] and ($facts['selinux_current_mode'] != 'disabled') {
+    if $facts['os']['selinux']['current_mode'] and ($facts['os']['selinux']['current_mode'] != 'disabled') {
       create_resources('selinux_login', $login_resources)
     }
   }

--- a/manifests/service.pp
+++ b/manifests/service.pp
@@ -3,7 +3,7 @@
 class selinux::service {
   assert_private()
 
-  if ($selinux::state == 'disabled') or !$facts['selinux'] {
+  if ($selinux::state == 'disabled') or !$facts['os']['selinux']['enabled'] {
     $_aux_service_ensure = 'stopped'
   }
   else {
@@ -24,9 +24,9 @@ class selinux::service {
           simplib::assert_optional_dependency($module_name, 'puppet/systemd')
 
           systemd::dropin_file { "${module_name}_mcstransd_hidepid_add_gid.conf":
-            unit          => "${selinux::mcstrans_service_name}.service",
-            notify        => Service[$selinux::mcstrans_service_name],
-            content       => @("SYSTEMD_OVERRIDE")
+            unit    => "${selinux::mcstrans_service_name}.service",
+            notify  => Service[$selinux::mcstrans_service_name],
+            content => @("SYSTEMD_OVERRIDE")
               [Service]
               SupplementaryGroups=${_proc_gid}
               | SYSTEMD_OVERRIDE

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "simp-selinux",
-  "version": "2.8.1",
+  "version": "2.9.0",
   "author": "SIMP Team",
   "summary": "manages the SELinux system state",
   "license": "Apache-2.0",
@@ -15,7 +15,7 @@
   "dependencies": [
     {
       "name": "puppetlabs/stdlib",
-      "version_requirement": ">= 6.6.0 < 8.0.0"
+      "version_requirement": ">= 8.0.0 < 9.0.0"
     },
     {
       "name": "simp/simplib",
@@ -30,7 +30,7 @@
     "optional_dependencies": [
       {
         "name": "puppet/systemd",
-        "version_requirement": ">= 3.0.0 < 4.0.0"
+        "version_requirement": ">= 4.0.2 < 6.0.0"
       }
     ]
   },
@@ -53,6 +53,12 @@
       "operatingsystem": "OracleLinux",
       "operatingsystemrelease": [
         "7",
+        "8"
+      ]
+    },
+    {
+      "operatingsystem": "Rocky",
+      "operatingsystemrelease": [
         "8"
       ]
     }

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -1,6 +1,25 @@
 require 'spec_helper'
 
 describe 'selinux' do
+  def mock_selinux_false_facts(os_facts)
+    os_facts[:selinux] = false
+    os_facts[:os][:selinux][:config_mode] = 'disabled'
+    os_facts[:os][:selinux][:current_mode] = 'disabled'
+    os_facts[:os][:selinux][:enabled] = false
+    os_facts[:os][:selinux][:enforced] = false
+    os_facts
+  end
+
+  def mock_selinux_enforcing_facts(os_facts)
+    os_facts[:selinux] = true
+    os_facts[:os][:selinux][:config_mode] = 'enforcing'
+    os_facts[:os][:selinux][:config_policy] = 'targeted'
+    os_facts[:os][:selinux][:current_mode] = 'enforcing'
+    os_facts[:os][:selinux][:enabled] = true
+    os_facts[:os][:selinux][:enforced] = true
+    os_facts
+  end
+
   on_supported_os.each do |os, os_facts|
     context "on #{os}" do
       let(:facts) do
@@ -237,10 +256,11 @@ describe 'selinux' do
             it { is_expected.to create_kernel_parameter('selinux').with_value(1).that_notifies('Reboot_notify[selinux]') }
             it { is_expected.to create_kernel_parameter('enforcing').with_value(0).that_notifies('Reboot_notify[selinux]') }
           end
+
           context 'ensure -> disabled' do
             let(:facts) do
               os_facts = os_facts.dup
-              os_facts[:selinux] = false
+              os_facts = mock_selinux_false_facts(os_facts)
               os_facts
             end
             let(:params) {{
@@ -254,7 +274,8 @@ describe 'selinux' do
           context 'ensure -> enforcing' do
             let(:facts) do
               os_facts = os_facts.dup
-              os_facts[:selinux] = false
+              os_facts = mock_selinux_false_facts(os_facts)
+              os_facts = mock_selinux_false_facts(os_facts)
               os_facts
             end
             let(:params) {{
@@ -268,7 +289,7 @@ describe 'selinux' do
           context 'ensure -> true' do
             let(:facts) do
               os_facts = os_facts.dup
-              os_facts[:selinux] = false
+              os_facts = mock_selinux_false_facts(os_facts)
               os_facts
             end
             let(:params) {{
@@ -282,7 +303,7 @@ describe 'selinux' do
           context 'ensure -> permissive' do
             let(:facts) do
               os_facts = os_facts.dup
-              os_facts[:selinux] = false
+              os_facts = mock_selinux_false_facts(os_facts)
               os_facts
             end
             let(:params) {{
@@ -342,7 +363,7 @@ describe 'selinux' do
         context 'when selinux is not disabled' do
           let(:facts) do
             os_facts = os_facts.dup
-            os_facts[:selinux_current_mode] = 'enforcing'
+            os_facts = mock_selinux_enforcing_facts(os_facts)
             os_facts
           end
 


### PR DESCRIPTION
This patch adds support for RockyLinux 8

The patch enforces a standardized asset baseline using simp/puppetsync,
and may also apply other updates to ensure conformity.