### PR TITLE
[puppetsync] Support simp-iptables 7.x

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,6 @@
+* Fri Sep 13 2024 Steven Pritchard <steve@sicura.us> - 2.13.0
+- [puppetsync] Update module dependencies to support simp-iptables 7.x
+
 * Mon Oct 23 2023 Steven Pritchard <steve@sicura.us> - 2.12.0
 - [puppetsync] Add EL9 support
 

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "simp-selinux",
-  "version": "2.12.0",
+  "version": "2.13.0",
   "author": "SIMP Team",
   "summary": "manages the SELinux system state",
   "license": "Apache-2.0",
@@ -30,7 +30,7 @@
     "optional_dependencies": [
       {
         "name": "puppet/systemd",
-        "version_requirement": ">= 4.0.2 < 7.0.0"
+        "version_requirement": ">= 4.0.2 < 8.0.0"
       }
     ]
   },

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -100,7 +100,6 @@ RSpec.configure do |c|
   c.mock_with :rspec
 
   c.module_path = File.join(fixture_path, 'modules')
-  c.manifest_dir = File.join(fixture_path, 'manifests') if c.respond_to?(:manifest_dir)
 
   c.hiera_config = File.join(fixture_path, 'hieradata', 'hiera.yaml')
 


### PR DESCRIPTION
Update module dependencies to support simp-iptables 7.x.