### PR TITLE
Cleanup for 4.0.0 release: migrate to 6.x stack and run acceptance under Vagrant

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -12,5 +12,3 @@ fixtures:
     vox_selinux:
       repo: https://github.com/simp/pupmod-voxpupuli-selinux.git
       branch: simp-master
-  symlinks:
-    selinux: "#{source_dir}"

--- a/.github/workflows/pr_tests.yml
+++ b/.github/workflows/pr_tests.yml
@@ -110,7 +110,7 @@ jobs:
           ruby-version: ${{matrix.puppet.ruby_version}}
           bundler-cache: true
       - run: 'command -v rpm || if command -v apt-get; then sudo apt-get update; sudo apt-get install -y rpm; fi ||:'
-      - run: 'bundle exec rake spec'
+      - run: 'bundle exec rake parallel_spec'
         continue-on-error: ${{matrix.puppet.experimental}}
 
   acceptance:

--- a/.github/workflows/pr_tests.yml
+++ b/.github/workflows/pr_tests.yml
@@ -112,31 +112,19 @@ jobs:
       - run: 'command -v rpm || if command -v apt-get; then sudo apt-get update; sudo apt-get install -y rpm; fi ||:'
       - run: 'bundle exec rake parallel_spec'
         continue-on-error: ${{matrix.puppet.experimental}}
-
   acceptance:
     runs-on:
       - ubuntu-latest
     strategy:
       matrix:
         node:
-          - docker_alma8
-          - docker_alma9
-          - docker_alma10
-          - docker_centos9
-          - docker_centos10
-          - docker_oel8
-          - docker_oel9
-          - docker_oel10
-          - docker_rhel8
-          - docker_rhel9
-          - docker_rhel10
-          - docker_rocky8
-          - docker_rocky9
-          - docker_rocky10
+          - almalinux8
+          - almalinux9
+          - almalinux10
       fail-fast: false
     steps:
       - name: checkout repo
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
       - name: setup ruby
         uses: ruby/setup-ruby@v1
         with:
@@ -144,10 +132,15 @@ jobs:
       - name: bundle install
         run: |
           bundle install
-      - name: Setup podman
+      - name: Setup libvirt for Vagrant
         run: |
-          systemctl start --user podman.socket
-          echo "DOCKER_HOST=unix:///run/user/$(id -u)/podman/podman.sock" >> "$GITHUB_ENV"
+          sudo add-apt-repository ppa:evgeni/vagrant
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends vagrant vagrant-libvirt libvirt-daemon-system libvirt-daemon qemu-system-x86 qemu-utils dnsmasq
+          sudo chmod 666 /var/run/libvirt/libvirt-sock
       - name: beaker
+        env:
+          BEAKER_HYPERVISOR: 'vagrant_libvirt'
+          VAGRANT_DEFAULT_PROVIDER: 'libvirt'
         run: |
           bundle exec rake beaker:suites[default,${{ matrix.node }}]

--- a/.github/workflows/pr_tests.yml
+++ b/.github/workflows/pr_tests.yml
@@ -10,9 +10,9 @@
 #
 # https://docs.github.com/en/actions/reference/events-that-trigger-workflows
 #
-
+---
 name: PR Tests
-on:
+'on':
   pull_request:
     types: [opened, reopened, synchronize]
 
@@ -110,45 +110,44 @@ jobs:
           ruby-version: ${{matrix.puppet.ruby_version}}
           bundler-cache: true
       - run: 'command -v rpm || if command -v apt-get; then sudo apt-get update; sudo apt-get install -y rpm; fi ||:'
-      - run: 'bundle exec rake parallel_spec'
+      - run: 'bundle exec rake spec'
         continue-on-error: ${{matrix.puppet.experimental}}
 
-  # The tests require reboots so using docker is not possible right now
-  # acceptance:
-  #   runs-on:
-  #     - ubuntu-latest
-  #   strategy:
-  #     matrix:
-  #       node:
-  #         - docker_alma8
-  #         - docker_alma9
-  #         - docker_alma10
-  #         - docker_centos9
-  #         - docker_centos10
-  #         - docker_oel8
-  #         - docker_oel9
-  #         - docker_oel10
-  #         - docker_rhel8
-  #         - docker_rhel9
-  #         - docker_rhel10
-  #         - docker_rocky8
-  #         - docker_rocky9
-  #         - docker_rocky10
-  #     fail-fast: false
-  #   steps:
-  #     - name: checkout repo
-  #       uses: actions/checkout@v4
-  #     - name: setup ruby
-  #       uses: ruby/setup-ruby@v1
-  #       with:
-  #         ruby-version: 3.2
-  #     - name: bundle install
-  #       run: |
-  #         bundle install
-  #     - name: Setup podman
-  #       run: |
-  #         systemctl start --user podman.socket
-  #         echo "DOCKER_HOST=unix:///run/user/$(id -u)/podman/podman.sock" >> "$GITHUB_ENV"
-  #     - name: beaker
-  #       run: |
-  #         bundle exec rake beaker:suites[default,${{ matrix.node }}]
+  acceptance:
+    runs-on:
+      - ubuntu-latest
+    strategy:
+      matrix:
+        node:
+          - docker_alma8
+          - docker_alma9
+          - docker_alma10
+          - docker_centos9
+          - docker_centos10
+          - docker_oel8
+          - docker_oel9
+          - docker_oel10
+          - docker_rhel8
+          - docker_rhel9
+          - docker_rhel10
+          - docker_rocky8
+          - docker_rocky9
+          - docker_rocky10
+      fail-fast: false
+    steps:
+      - name: checkout repo
+        uses: actions/checkout@v6
+      - name: setup ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: 3.4.9
+      - name: bundle install
+        run: |
+          bundle install
+      - name: Setup podman
+        run: |
+          systemctl start --user podman.socket
+          echo "DOCKER_HOST=unix:///run/user/$(id -u)/podman/podman.sock" >> "$GITHUB_ENV"
+      - name: beaker
+        run: |
+          bundle exec rake beaker:suites[default,${{ matrix.node }}]

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -2,6 +2,7 @@
 - Remove unmaintained Compliance Engine data
 - Drop support for end-of-life CentOS 8
 - Drop Puppet 7 support; require openvox >= 8 < 9
+- Point `issues_url` at GitHub Issues; allow `simp-simplib` 5.x and `puppet-systemd` 9.x.
 
 * Sat Dec 06 2025 Steven Pritchard <steve@sicura.us> - 3.0.1
 - Clean up for rubocop

--- a/Gemfile
+++ b/Gemfile
@@ -13,10 +13,10 @@ gem_sources.each { |gem_source| source gem_source }
 group :syntax do
   gem 'metadata-json-lint'
   gem 'puppet-lint-trailing_comma-check', require: false
-  gem 'rubocop', '~> 1.88.0'
+  gem 'rubocop', '~> 1.85'
   gem 'rubocop-performance', '~> 1.26.0'
   gem 'rubocop-rake', '~> 0.7.0'
-  gem 'rubocop-rspec', '~> 3.10.0'
+  gem 'rubocop-rspec', '~> 3.9'
 end
 
 group :test do
@@ -30,13 +30,12 @@ group :test do
   ['openvox', 'puppet'].each do |gem_name|
     gem gem_name, binding.local_variable_get("#{gem_name}_version".to_sym)
   end
-  gem 'puppetlabs_spec_helper', '~> 8.0.0'
   gem 'puppet-strings'
   gem 'rake'
   gem 'rspec'
   gem 'rspec-puppet'
   # renovate: datasource=rubygems versioning=ruby
-  gem 'simp-rake-helpers', ENV.fetch('SIMP_RAKE_HELPERS_VERSION', '~> 5.25.0')
+  gem 'simp-rake-helpers', ENV.fetch('SIMP_RAKE_HELPERS_VERSION', '~> 6.0')
   # renovate: datasource=rubygems versioning=ruby
   gem 'simp-rspec-puppet-facts', ENV.fetch('SIMP_RSPEC_PUPPET_FACTS_VERSION', '~> 4.0.0')
   gem 'syslog', require: false
@@ -54,7 +53,7 @@ group :system_tests do
   gem 'beaker_puppet_helpers'
   gem 'beaker-rspec'
   # renovate: datasource=rubygems versioning=ruby
-  gem 'simp-beaker-helpers', ENV.fetch('SIMP_BEAKER_HELPERS_VERSION', '~> 2.0.0')
+  gem 'simp-beaker-helpers', ENV.fetch('SIMP_BEAKER_HELPERS_VERSION', '~> 3.1')
 end
 
 # Evaluate extra gemfiles if they exist

--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -183,7 +183,7 @@ The following parameters are available in the `selinux::install` class:
 
 Data type: `Boolean`
 
-
+Whether to manage the SELinux utility packages
 
 Default value: `pick(getvar('selinux::manage_utils_package'), true)`
 
@@ -191,7 +191,7 @@ Default value: `pick(getvar('selinux::manage_utils_package'), true)`
 
 Data type: `Array[String]`
 
-
+The SELinux utility packages to manage when ``manage_utils_package`` is set
 
 Default value: `['checkpolicy']`
 
@@ -199,7 +199,7 @@ Default value: `['checkpolicy']`
 
 Data type: `Boolean`
 
-
+Whether to manage the MCS translation daemon package
 
 Default value: `simplib::lookup('selinux::manage_mcstrans_package')`
 
@@ -207,7 +207,7 @@ Default value: `simplib::lookup('selinux::manage_mcstrans_package')`
 
 Data type: `String`
 
-
+The name of the MCS translation daemon package
 
 Default value: `simplib::lookup('selinux::mcstrans_package_name')`
 
@@ -215,7 +215,7 @@ Default value: `simplib::lookup('selinux::mcstrans_package_name')`
 
 Data type: `Boolean`
 
-
+Whether to manage the ``restorecond`` package
 
 Default value: `simplib::lookup('selinux::manage_restorecond_package')`
 
@@ -223,7 +223,7 @@ Default value: `simplib::lookup('selinux::manage_restorecond_package')`
 
 Data type: `String`
 
-
+The name of the ``restorecond`` package
 
 Default value: `simplib::lookup('selinux::restorecond_package_name')`
 
@@ -231,9 +231,9 @@ Default value: `simplib::lookup('selinux::restorecond_package_name')`
 
 Data type: `String`
 
+The ``ensure`` value applied to all packages managed by this class
 
-
-Default value: `simplib::lookup('selinux::package_ensure', { 'default_value' => simplib::lookup('simp_options::package_ensure', { 'default_value' => 'present' } ) } )`
+Default value: `simplib::lookup('selinux::package_ensure', { 'default_value' => simplib::lookup('simp_options::package_ensure', { 'default_value' => 'present' }) })`
 
 ### <a name="selinux--service"></a>`selinux::service`
 
@@ -264,13 +264,13 @@ Default value: `present`
 
 ##### `mls_range`
 
-Valid values: `/^.+$/`
+Valid values: `%r{^.+$}`
 
 The Multi-Level Security range to be applied to the login
 
 ##### `seuser`
 
-Valid values: `/^.+$/`
+Valid values: `%r{^.+$}`
 
 The SELinux user to which the login should be mapped.
 You can get a list by running `semanage user -l`

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -76,7 +76,6 @@ class selinux (
   Enum['targeted','mls'] $mode                        = 'targeted',
   Optional[Hash]         $login_resources             = undef
 ) {
-
   $state = $ensure ? {
     true    => 'enforcing',
     false   => 'disabled',

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -1,5 +1,26 @@
 # @summary Install selinux-related packages not managed by vox_selinux
 #
+# @param manage_utils_package
+#   Whether to manage the SELinux utility packages
+#
+# @param utils_packages
+#   The SELinux utility packages to manage when ``manage_utils_package`` is set
+#
+# @param manage_mcstrans_package
+#   Whether to manage the MCS translation daemon package
+#
+# @param mcstrans_package_name
+#   The name of the MCS translation daemon package
+#
+# @param manage_restorecond_package
+#   Whether to manage the ``restorecond`` package
+#
+# @param restorecond_package_name
+#   The name of the ``restorecond`` package
+#
+# @param package_ensure
+#   The ``ensure`` value applied to all packages managed by this class
+#
 class selinux::install (
   Boolean       $manage_utils_package       = pick(getvar('selinux::manage_utils_package'), true),
   Array[String] $utils_packages             = ['checkpolicy'],
@@ -7,17 +28,17 @@ class selinux::install (
   String        $mcstrans_package_name      = simplib::lookup('selinux::mcstrans_package_name'),
   Boolean       $manage_restorecond_package = simplib::lookup('selinux::manage_restorecond_package'),
   String        $restorecond_package_name   = simplib::lookup('selinux::restorecond_package_name'),
-  String        $package_ensure             = simplib::lookup('selinux::package_ensure', { 'default_value' => simplib::lookup('simp_options::package_ensure', { 'default_value' => 'present' } ) } )
-){
+  String        $package_ensure             = simplib::lookup('selinux::package_ensure', { 'default_value' => simplib::lookup('simp_options::package_ensure', { 'default_value' => 'present' }) })
+) {
   if $manage_utils_package {
-    ensure_packages($utils_packages, { 'ensure' =>  $package_ensure})
+    ensure_packages($utils_packages, { 'ensure' => $package_ensure })
   }
 
   if $manage_mcstrans_package {
-    ensure_packages([$mcstrans_package_name], { 'ensure' =>  $package_ensure})
+    ensure_packages([$mcstrans_package_name], { 'ensure' => $package_ensure })
   }
 
   if $manage_restorecond_package {
-    ensure_packages([$restorecond_package_name], { 'ensure' =>  $package_ensure})
+    ensure_packages([$restorecond_package_name], { 'ensure' => $package_ensure })
   }
 }

--- a/manifests/service.pp
+++ b/manifests/service.pp
@@ -13,7 +13,6 @@ class selinux::service {
   }
 
   if $selinux::manage_mcstrans_service {
-
     if 'systemd' in pick($facts.dig('init_systems') , []) {
       # If hidepid is set > 0 and a GID is set, then the service must have that
       # GID added to its supplementary groups at start time

--- a/metadata.json
+++ b/metadata.json
@@ -6,7 +6,7 @@
   "license": "Apache-2.0",
   "source": "https://github.com/simp/pupmod-simp-selinux",
   "project_page": "https://github.com/simp/pupmod-simp-selinux",
-  "issues_url": "https://simp-project.atlassian.net",
+  "issues_url": "https://github.com/simp/pupmod-simp-selinux/issues",
   "tags": [
     "simp",
     "selinux",
@@ -19,7 +19,7 @@
     },
     {
       "name": "simp/simplib",
-      "version_requirement": ">= 4.9.0 < 5.0.0"
+      "version_requirement": ">= 4.9.0 < 6.0.0"
     },
     {
       "name": "simp/vox_selinux",
@@ -30,7 +30,7 @@
     "optional_dependencies": [
       {
         "name": "puppet/systemd",
-        "version_requirement": ">= 4.0.2 < 9.0.0"
+        "version_requirement": ">= 4.0.2 < 10.0.0"
       }
     ]
   },

--- a/spec/acceptance/nodesets/almalinux10.yml
+++ b/spec/acceptance/nodesets/almalinux10.yml
@@ -1,0 +1,19 @@
+---
+HOSTS:
+  almalinux10:
+    roles:
+    - default
+    - master
+    - server
+    - el10
+    platform: el-10-x86_64
+    box: almalinux/10
+    hypervisor: "<%= ENV.fetch('BEAKER_HYPERVISOR', 'vagrant') %>"
+    vagrant_memsize: 2048
+    vagrant_cpus: 2
+    family: almalinux-cloud/almalinux-10
+    gce_machine_type: n1-standard-2
+CONFIG:
+  log_level: verbose
+  type: aio
+  puppet_collection: "<%= ENV.fetch('BEAKER_PUPPET_COLLECTION', 'openvox8') %>"

--- a/spec/acceptance/nodesets/almalinux8.yml
+++ b/spec/acceptance/nodesets/almalinux8.yml
@@ -1,0 +1,19 @@
+---
+HOSTS:
+  almalinux8:
+    roles:
+    - default
+    - master
+    - server
+    - el8
+    platform: el-8-x86_64
+    box: almalinux/8
+    hypervisor: "<%= ENV.fetch('BEAKER_HYPERVISOR', 'vagrant') %>"
+    vagrant_memsize: 2048
+    vagrant_cpus: 2
+    family: almalinux-cloud/almalinux-8
+    gce_machine_type: n1-standard-2
+CONFIG:
+  log_level: verbose
+  type: aio
+  puppet_collection: "<%= ENV.fetch('BEAKER_PUPPET_COLLECTION', 'openvox8') %>"

--- a/spec/acceptance/nodesets/almalinux9.yml
+++ b/spec/acceptance/nodesets/almalinux9.yml
@@ -1,0 +1,19 @@
+---
+HOSTS:
+  almalinux9:
+    roles:
+    - default
+    - master
+    - server
+    - el9
+    platform: el-9-x86_64
+    box: almalinux/9
+    hypervisor: "<%= ENV.fetch('BEAKER_HYPERVISOR', 'vagrant') %>"
+    vagrant_memsize: 2048
+    vagrant_cpus: 2
+    family: almalinux-cloud/almalinux-9
+    gce_machine_type: n1-standard-2
+CONFIG:
+  log_level: verbose
+  type: aio
+  puppet_collection: "<%= ENV.fetch('BEAKER_PUPPET_COLLECTION', 'openvox8') %>"

--- a/spec/acceptance/nodesets/centos10.yml
+++ b/spec/acceptance/nodesets/centos10.yml
@@ -1,0 +1,19 @@
+---
+HOSTS:
+  centos10:
+    roles:
+    - default
+    - master
+    - server
+    - el10
+    platform: el-10-x86_64
+    box: generic/centos10s
+    hypervisor: "<%= ENV.fetch('BEAKER_HYPERVISOR', 'vagrant') %>"
+    vagrant_memsize: 2048
+    vagrant_cpus: 2
+    family: centos-cloud/centos-stream-10
+    gce_machine_type: n1-standard-2
+CONFIG:
+  log_level: verbose
+  type: aio
+  puppet_collection: "<%= ENV.fetch('BEAKER_PUPPET_COLLECTION', 'openvox8') %>"

--- a/spec/acceptance/nodesets/centos9.yml
+++ b/spec/acceptance/nodesets/centos9.yml
@@ -1,0 +1,19 @@
+---
+HOSTS:
+  centos9:
+    roles:
+    - default
+    - master
+    - server
+    - el9
+    platform: el-9-x86_64
+    box: generic/centos9s
+    hypervisor: "<%= ENV.fetch('BEAKER_HYPERVISOR', 'vagrant') %>"
+    vagrant_memsize: 2048
+    vagrant_cpus: 2
+    family: centos-cloud/centos-stream-9
+    gce_machine_type: n1-standard-2
+CONFIG:
+  log_level: verbose
+  type: aio
+  puppet_collection: "<%= ENV.fetch('BEAKER_PUPPET_COLLECTION', 'openvox8') %>"

--- a/spec/acceptance/nodesets/oel10.yml
+++ b/spec/acceptance/nodesets/oel10.yml
@@ -1,0 +1,17 @@
+---
+HOSTS:
+  oel10:
+    roles:
+    - default
+    - master
+    - server
+    - el10
+    platform: el-10-x86_64
+    box: generic/oracle10
+    hypervisor: "<%= ENV.fetch('BEAKER_HYPERVISOR', 'vagrant') %>"
+    vagrant_memsize: 2048
+    vagrant_cpus: 2
+CONFIG:
+  log_level: verbose
+  type: aio
+  puppet_collection: "<%= ENV.fetch('BEAKER_PUPPET_COLLECTION', 'openvox8') %>"

--- a/spec/acceptance/nodesets/oel8.yml
+++ b/spec/acceptance/nodesets/oel8.yml
@@ -1,0 +1,17 @@
+---
+HOSTS:
+  oel8:
+    roles:
+    - default
+    - master
+    - server
+    - el8
+    platform: el-8-x86_64
+    box: generic/oracle8
+    hypervisor: "<%= ENV.fetch('BEAKER_HYPERVISOR', 'vagrant') %>"
+    vagrant_memsize: 2048
+    vagrant_cpus: 2
+CONFIG:
+  log_level: verbose
+  type: aio
+  puppet_collection: "<%= ENV.fetch('BEAKER_PUPPET_COLLECTION', 'openvox8') %>"

--- a/spec/acceptance/nodesets/oel9.yml
+++ b/spec/acceptance/nodesets/oel9.yml
@@ -1,0 +1,17 @@
+---
+HOSTS:
+  oel9:
+    roles:
+    - default
+    - master
+    - server
+    - el9
+    platform: el-9-x86_64
+    box: generic/oracle9
+    hypervisor: "<%= ENV.fetch('BEAKER_HYPERVISOR', 'vagrant') %>"
+    vagrant_memsize: 2048
+    vagrant_cpus: 2
+CONFIG:
+  log_level: verbose
+  type: aio
+  puppet_collection: "<%= ENV.fetch('BEAKER_PUPPET_COLLECTION', 'openvox8') %>"

--- a/spec/acceptance/nodesets/rhel10.yml
+++ b/spec/acceptance/nodesets/rhel10.yml
@@ -1,0 +1,19 @@
+---
+HOSTS:
+  rhel10:
+    roles:
+    - default
+    - master
+    - server
+    - el10
+    platform: el-10-x86_64
+    box: generic/rhel10
+    hypervisor: "<%= ENV.fetch('BEAKER_HYPERVISOR', 'vagrant') %>"
+    vagrant_memsize: 2048
+    vagrant_cpus: 2
+    family: rhel-cloud/rhel-10
+    gce_machine_type: n1-standard-2
+CONFIG:
+  log_level: verbose
+  type: aio
+  puppet_collection: "<%= ENV.fetch('BEAKER_PUPPET_COLLECTION', 'openvox8') %>"

--- a/spec/acceptance/nodesets/rhel8.yml
+++ b/spec/acceptance/nodesets/rhel8.yml
@@ -1,0 +1,19 @@
+---
+HOSTS:
+  rhel8:
+    roles:
+    - default
+    - master
+    - server
+    - el8
+    platform: el-8-x86_64
+    box: generic/rhel8
+    hypervisor: "<%= ENV.fetch('BEAKER_HYPERVISOR', 'vagrant') %>"
+    vagrant_memsize: 2048
+    vagrant_cpus: 2
+    family: rhel-cloud/rhel-8
+    gce_machine_type: n1-standard-2
+CONFIG:
+  log_level: verbose
+  type: aio
+  puppet_collection: "<%= ENV.fetch('BEAKER_PUPPET_COLLECTION', 'openvox8') %>"

--- a/spec/acceptance/nodesets/rhel9.yml
+++ b/spec/acceptance/nodesets/rhel9.yml
@@ -1,0 +1,19 @@
+---
+HOSTS:
+  rhel9:
+    roles:
+    - default
+    - master
+    - server
+    - el9
+    platform: el-9-x86_64
+    box: generic/rhel9
+    hypervisor: "<%= ENV.fetch('BEAKER_HYPERVISOR', 'vagrant') %>"
+    vagrant_memsize: 2048
+    vagrant_cpus: 2
+    family: rhel-cloud/rhel-9
+    gce_machine_type: n1-standard-2
+CONFIG:
+  log_level: verbose
+  type: aio
+  puppet_collection: "<%= ENV.fetch('BEAKER_PUPPET_COLLECTION', 'openvox8') %>"

--- a/spec/acceptance/nodesets/rocky10.yml
+++ b/spec/acceptance/nodesets/rocky10.yml
@@ -1,0 +1,19 @@
+---
+HOSTS:
+  rocky10:
+    roles:
+    - default
+    - master
+    - server
+    - el10
+    platform: el-10-x86_64
+    box: rockylinux/10
+    hypervisor: "<%= ENV.fetch('BEAKER_HYPERVISOR', 'vagrant') %>"
+    vagrant_memsize: 2048
+    vagrant_cpus: 2
+    family: rocky-linux-cloud/rocky-linux-10
+    gce_machine_type: n1-standard-2
+CONFIG:
+  log_level: verbose
+  type: aio
+  puppet_collection: "<%= ENV.fetch('BEAKER_PUPPET_COLLECTION', 'openvox8') %>"

--- a/spec/acceptance/nodesets/rocky8.yml
+++ b/spec/acceptance/nodesets/rocky8.yml
@@ -1,0 +1,19 @@
+---
+HOSTS:
+  rocky8:
+    roles:
+    - default
+    - master
+    - server
+    - el8
+    platform: el-8-x86_64
+    box: rockylinux/8
+    hypervisor: "<%= ENV.fetch('BEAKER_HYPERVISOR', 'vagrant') %>"
+    vagrant_memsize: 2048
+    vagrant_cpus: 2
+    family: rocky-linux-cloud/rocky-linux-8
+    gce_machine_type: n1-standard-2
+CONFIG:
+  log_level: verbose
+  type: aio
+  puppet_collection: "<%= ENV.fetch('BEAKER_PUPPET_COLLECTION', 'openvox8') %>"

--- a/spec/acceptance/nodesets/rocky9.yml
+++ b/spec/acceptance/nodesets/rocky9.yml
@@ -1,0 +1,19 @@
+---
+HOSTS:
+  rocky9:
+    roles:
+    - default
+    - master
+    - server
+    - el9
+    platform: el-9-x86_64
+    box: rockylinux/9
+    hypervisor: "<%= ENV.fetch('BEAKER_HYPERVISOR', 'vagrant') %>"
+    vagrant_memsize: 2048
+    vagrant_cpus: 2
+    family: rocky-linux-cloud/rocky-linux-9
+    gce_machine_type: n1-standard-2
+CONFIG:
+  log_level: verbose
+  type: aio
+  puppet_collection: "<%= ENV.fetch('BEAKER_PUPPET_COLLECTION', 'openvox8') %>"

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -8,7 +8,7 @@
 # The next baseline sync will overwrite any local changes made to this file.
 # ------------------------------------------------------------------------------
 
-require 'puppetlabs_spec_helper/module_spec_helper'
+require 'voxpupuli/test/spec_helper'
 require 'rspec-puppet'
 require 'simp/rspec-puppet-facts'
 include Simp::RspecPuppetFacts


### PR DESCRIPTION
## Summary

Began as the 4.0.0 metadata cleanup; grew to the test-stack migration and a correction to how this module's acceptance suite is run. **No manifest/behavior changes** — the substantive change here is to the CI harness.

### Metadata cleanup
- `issues_url` → GitHub Issues; allow `simp-simplib` 5.x and `puppet-systemd` 9.x

### Test stack migration
- `simp-rake-helpers ~> 6.0` / `simp-beaker-helpers ~> 3.1`; voxpupuli-test/puppet_fixtures; drop `puppetlabs_spec_helper`; `rubocop ~> 1.85`
- Document the `selinux::install` parameters (the newer puppet-lint fails the build on the pre-existing missing `@param` docs); regenerate REFERENCE.md

### Acceptance: docker → Vagrant
The suite is entirely kernel-level — it toggles the SELinux enforcing state, asserts `getenforce` transitions (Enforcing/Permissive/Disabled), and reboots the host repeatedly. **None of that works in a container**: inside docker/podman `getenforce` reports the host's state (or `Disabled`, no selinuxfs) regardless of config, and `host.reboot` cannot work — so the docker matrix could never reach `Enforcing` and was testing nothing (it also failed to even apply). Point the acceptance matrix at the Vagrant nodesets (`almalinux8/9/10`), mirroring the other kernel-level modules (e.g. pupmod-simp-ssh).

> Note: `pr_tests.yml` carries the puppetsync marker but the acceptance matrix is per-module in practice; this edit is intentionally kept structurally identical to the ssh/pam vagrant jobs for a follow-up puppetsync-template fix.

### Validation (local Vagrant, real enforcing↔disabled transitions across reboots)
almalinux8/9/10 each: 18 examples, 0 failures, 1 pending · unit: 897 examples, 0 failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)
