### PR TITLE
Fix incorrect hiera key displayed in test name

### DIFF
--- a/spec/acceptance/suites/default/00_default_spec.rb
+++ b/spec/acceptance/suites/default/00_default_spec.rb
@@ -53,7 +53,7 @@ describe 'selinux class' do
       end
     end
 
-    context 'with simp_options::selinux: false' do
+    context 'with selinux:ensure: false' do
       let(:hieradata) do
         {
           'selinux::ensure' => false,


### PR DESCRIPTION
Context name still referenced an ancient global catalyst.
The actual test already uses the correct key.